### PR TITLE
Add composer allow-plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
         with:
           path: mediawiki/extensions/WikibaseRDF
 
+      - name: Composer allow-plugins
+        run: composer config --no-plugins allow-plugins.composer/installers true
+
       - run: composer update
 
       - name: Run update.php
@@ -125,6 +128,9 @@ jobs:
         with:
           path: mediawiki/extensions/WikibaseRDF
 
+      - name: Composer allow-plugins
+        run: composer config --no-plugins allow-plugins.composer/installers true
+
       - run: composer update
 
       - name: Composer install
@@ -181,6 +187,9 @@ jobs:
           - uses: actions/checkout@v2
             with:
                 path: mediawiki/extensions/WikibaseRDF
+
+          - name: Composer allow-plugins
+            run: composer config --no-plugins allow-plugins.composer/installers true
 
           - run: composer update
 
@@ -239,5 +248,3 @@ jobs:
         run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
 
       - run: vendor/bin/phpcs -p -s
-
-

--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
 	},
 	"extra": {
 		"installer-name": "WikibaseRDF"
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true
+		}
 	}
 }


### PR DESCRIPTION
Temporary CI solution.

Not sure if we have to wait for something like this in upstream: https://gerrit.wikimedia.org/r/c/mediawiki/core/+/813308/2
Or this https://github.com/wikimedia/composer-merge-plugin/issues/229

Either way, it's necessary to do this for MW as well as for the extension.