### PR TITLE
Add initial predicate configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,16 @@ You can verify the extension was enabled successfully by opening your wikis Spec
 
 Configuration can be changed via [LocalSettings.php].
 
-TODO
+### Allowed predicates
+
+```php
+$wgWikibaseRdfPredicates = [
+	'owl:sameAs',
+	'owl:SymmetricProperty',
+	'rdfs:subClassOf',
+	'rdfs:subPropertyOf',
+];
+```
 
 ## Development
 

--- a/extension.json
+++ b/extension.json
@@ -53,6 +53,10 @@
 	],
 
 	"config": {
+		"WikibaseRdfPredicates": {
+			"description": "List of allowed predicates.",
+			"value": []
+		}
 	},
 
 	"ResourceFileModulePaths": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9,3 +9,8 @@ parameters:
 			message: "#^Constant WB_NS_PROPERTY not found\\.$#"
 			count: 1
 			path: src/EntryPoints/MediaWikiHooks.php
+
+		-
+			message: "#^Method ProfessionalWiki\\\\WikibaseRDF\\\\WikibaseRdfExtension\\:\\:getAllowedPredicates\\(\\) should return array\\<string\\> but returns array\\.$#"
+			count: 1
+			path: src/WikibaseRdfExtension.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8,4 +8,10 @@
       <code>$array</code>
     </MixedAssignment>
   </file>
+  <file src="src/WikibaseRdfExtension.php">
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>(array)MediaWikiServices::getInstance()-&gt;getMainConfig()-&gt;get( 'WikibaseRdfPredicates' )</code>
+      <code>string[]</code>
+    </MixedReturnTypeCoercion>
+  </file>
 </files>

--- a/src/EntryPoints/Rest/SaveMappingsApi.php
+++ b/src/EntryPoints/Rest/SaveMappingsApi.php
@@ -29,6 +29,7 @@ class SaveMappingsApi extends SimpleHandler {
 	public function run( string $entityId ): array {
 		$body = $this->getRequest()->getBody()->getContents();
 		$mappings = $this->mappingListSerializer->fromJson( $body );
+		// TODO: validate predicates are allowed
 		$this->repository->setMappings( $this->getEntityId( $entityId ), $mappings );
 
 		// TOOD: Return setMappings status. And anything else?

--- a/src/Presentation/StubMappingsPresenter.php
+++ b/src/Presentation/StubMappingsPresenter.php
@@ -15,6 +15,14 @@ class StubMappingsPresenter implements MappingsPresenter {
 
 	private string $response = '';
 
+	/**
+	 * @param string[] $allowedPredicates
+	 */
+	public function __construct(
+		private array $allowedPredicates
+	) {
+	}
+
 	public function showMappings( MappingList $mappingList ): void {
 		$mappingsHtml = '';
 
@@ -45,7 +53,7 @@ class StubMappingsPresenter implements MappingsPresenter {
 
 	private function createEditableRow( string $relationship, string $url ): string {
 		return '<div class="wikibase-rdf-row">'
-			. '<div class="wikibase-rdf-predicate"><select><option>' . $relationship . '</option></select></div>'
+			. '<div class="wikibase-rdf-predicate">' . $this->createPredicateSelect( $relationship ) . '</div>'
 			. '<div class="wikibase-rdf-object"><input value="' . $url . '"></div>'
 			. '<div class="wikibase-rdf-actions">'
 			. '<a href="#" class="wikibase-rdf-action-save"><span class="icon"></span>' . wfMessage( 'wikibase-rdf-mappings-action-save' ) . '</a> '
@@ -53,6 +61,20 @@ class StubMappingsPresenter implements MappingsPresenter {
 			. '<a href="#" class="wikibase-rdf-action-cancel"><span class="icon"></span>' . wfMessage( 'wikibase-rdf-mappings-action-cancel' ) . '</a>'
 			. '</div>'
 			. '</div>';
+	}
+
+	private function createPredicateSelect( string $selected ): string {
+		$html = '<select>';
+		foreach ( $this->allowedPredicates as $predicate ) {
+			// TOOD: selection will be handled by JS
+			$html .= '<option' . ( $predicate == $selected ? ' selected' : '' ) . '>' . $predicate . '</option>';
+		}
+		// TODO: handle removed/changed allowed predicates
+		if ( !in_array( $selected, $this->allowedPredicates ) ) {
+			$html .= '<option selected>' . $selected . '</option>';
+		}
+		$html .= '</select>';
+		return $html;
 	}
 
 	private function createRow( string $relationship, string $url ): string {

--- a/src/WikibaseRdfExtension.php
+++ b/src/WikibaseRdfExtension.php
@@ -37,7 +37,7 @@ class WikibaseRdfExtension {
 	}
 
 	public function newStubMappingsPresenter(): StubMappingsPresenter {
-		return new StubMappingsPresenter();
+		return new StubMappingsPresenter( self::getAllowedPredicates() );
 	}
 
 	public function newShowMappingsUseCase( MappingsPresenter $presenter, User $user ): ShowMappingsUseCase {
@@ -104,6 +104,13 @@ class WikibaseRdfExtension {
 			),
 			$this->newMappingListSerializer()
 		);
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private static function getAllowedPredicates(): array {
+		return (array)MediaWikiServices::getInstance()->getMainConfig()->get( 'WikibaseRdfPredicates' );
 	}
 
 }

--- a/tests/Presentation/StubMappingsPresenterTest.php
+++ b/tests/Presentation/StubMappingsPresenterTest.php
@@ -10,8 +10,18 @@ use ProfessionalWiki\WikibaseRDF\Presentation\StubMappingsPresenter;
  */
 class StubMappingsPresenterTest extends TestCase {
 
+	/**
+	 * @return string[]
+	 */
+	private function getAllowedPredicates(): array {
+		return [
+			'owl:sameAs',
+			'skos:exactMatch',
+		];
+	}
+
 	public function testMappingValuesAreDisplayed(): void {
-		$presenter = new StubMappingsPresenter();
+		$presenter = new StubMappingsPresenter( $this->getAllowedPredicates() );
 		$mapping1 = new Mapping( 'owl:sameAs', 'http://www.w3.org/2000/01/rdf-schema#subClassOf' );
 		$mapping2 = new Mapping( 'skos:exactMatch', 'http://www.example.com/foo' );
 


### PR DESCRIPTION
First part of #36 

This adds the config variable and displays it in the stub UI.

Follow-ups before completing #36:
* add allowed predicate validation (possibly pending https://github.com/ProfessionalWiki/WikibaseRDF/discussions/36)
* add API error handling to see the validation outcome (https://github.com/ProfessionalWiki/WikibaseRDF/issues/33)