### PR TITLE
Add Save Mappings API response handling

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -14,5 +14,8 @@
 	"wikibase-rdf-mappings-action-remove": "remove",
 	"wikibase-rdf-mappings-action-cancel": "cancel",
 	"wikibase-rdf-mappings-action-edit": "edit",
-	"wikibase-rdf-mappings-action-add": "add mapping"
+	"wikibase-rdf-mappings-action-add": "add mapping",
+
+	"wikibase-rdf-save-mappings-invalid-mappings": "Cannot save invalid mappings",
+	"wikibase-rdf-save-mappings-save-failed": "Save failed"
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -26,8 +26,15 @@
 	<issueHandlers>
 		<UndefinedConstant errorLevel="suppress" />
 
+		<PossiblyNullReference>
+			<errorLevel type="suppress">
+				<directory name="tests" />
+			</errorLevel>
+		</PossiblyNullReference>
+
 		<PropertyNotSetInConstructor>
 			<errorLevel type="suppress">
+				<directory name="src" />
 				<directory name="tests" />
 			</errorLevel>
 		</PropertyNotSetInConstructor>

--- a/src/Application/SaveMappings/SaveMappingsPresenter.php
+++ b/src/Application/SaveMappings/SaveMappingsPresenter.php
@@ -1,0 +1,17 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Application\SaveMappings;
+
+use ProfessionalWiki\WikibaseRDF\Application\MappingList;
+
+interface SaveMappingsPresenter {
+
+	public function presentSuccess(): void;
+
+	public function presentInvalidMappings( MappingList $mappings ): void;
+
+	public function presentSaveFailed(): void;
+
+}

--- a/src/Application/SaveMappings/SaveMappingsUseCase.php
+++ b/src/Application/SaveMappings/SaveMappingsUseCase.php
@@ -1,0 +1,49 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Application\SaveMappings;
+
+use ProfessionalWiki\WikibaseRDF\Application\Mapping;
+use ProfessionalWiki\WikibaseRDF\Application\MappingList;
+use ProfessionalWiki\WikibaseRDF\Application\MappingRepository;
+use Throwable;
+use Wikibase\DataModel\Entity\EntityId;
+
+class SaveMappingsUseCase {
+
+	/**
+	 * @param string[] $allowedPredicates
+	 */
+	public function __construct(
+		private SaveMappingsPresenter $presenter,
+		private MappingRepository $repository,
+		private array $allowedPredicates
+	) {
+	}
+
+	public function saveMappings( EntityId $entityId, MappingList $mappings ): void {
+		$invalidMappings = $this->getInvalidMappings( $mappings );
+		if ( $invalidMappings->asArray() !== [] ) {
+			$this->presenter->presentInvalidMappings( $invalidMappings );
+			return;
+		}
+
+		try {
+			$this->repository->setMappings( $entityId, $mappings );
+			$this->presenter->presentSuccess();
+		} catch ( Throwable ) {
+			$this->presenter->presentSaveFailed();
+		}
+	}
+
+	private function getInvalidMappings( MappingList $mappings ): MappingList {
+		return new MappingList(
+			array_filter(
+				$mappings->asArray(),
+				fn( Mapping $mapping ) => !in_array( $mapping->predicate, $this->allowedPredicates )
+			)
+		);
+	}
+
+}

--- a/src/EntryPoints/Rest/GetMappingsApi.php
+++ b/src/EntryPoints/Rest/GetMappingsApi.php
@@ -32,6 +32,13 @@ class GetMappingsApi extends SimpleHandler {
 
 	/**
 	 * @inheritDoc
+	 */
+	public function needsWriteAccess() {
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
 	 * @return array<string, array<string, mixed>>
 	 */
 	public function getParamSettings(): array {

--- a/src/Presentation/RestSaveMappingsPresenter.php
+++ b/src/Presentation/RestSaveMappingsPresenter.php
@@ -1,0 +1,47 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Presentation;
+
+use MediaWiki\Rest\Response;
+use MediaWiki\Rest\ResponseFactory;
+use ProfessionalWiki\WikibaseRDF\Application\MappingList;
+use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsPresenter;
+use ProfessionalWiki\WikibaseRDF\MappingListSerializer;
+use Wikimedia\Message\MessageValue;
+
+class RestSaveMappingsPresenter implements SaveMappingsPresenter {
+
+	private Response $response;
+
+	public function __construct(
+		private ResponseFactory $responseFactory,
+		private MappingListSerializer $mappingListSerializer
+	) {
+	}
+
+	public function presentSuccess(): void {
+		$this->response = $this->responseFactory->createNoContent();
+	}
+
+	public function presentInvalidMappings( MappingList $mappings ): void {
+		$this->response = $this->responseFactory->createLocalizedHttpError(
+			400,
+			MessageValue::new( 'wikibase-rdf-save-mappings-invalid-mappings' ),
+			[ 'invalidMappings' => $this->mappingListSerializer->mappingListToArray( $mappings ) ]
+		);
+	}
+
+	public function presentSaveFailed(): void {
+		$this->response = $this->responseFactory->createLocalizedHttpError(
+			500,
+			MessageValue::new( 'wikibase-rdf-save-mappings-save-failed' )
+		);
+	}
+
+	public function getResponse(): Response {
+		return $this->response;
+	}
+
+}

--- a/src/WikibaseRdfExtension.php
+++ b/src/WikibaseRdfExtension.php
@@ -5,7 +5,10 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseRDF;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Rest\ResponseFactory;
 use ProfessionalWiki\WikibaseRDF\Application\MappingRepository;
+use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsPresenter;
+use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsUseCase;
 use ProfessionalWiki\WikibaseRDF\Application\ShowMappingsUseCase;
 use ProfessionalWiki\WikibaseRDF\Persistence\ContentSlotMappingRepository;
 use ProfessionalWiki\WikibaseRDF\Persistence\EntityContentRepository;
@@ -14,6 +17,7 @@ use ProfessionalWiki\WikibaseRDF\Presentation\MappingsPresenter;
 use ProfessionalWiki\WikibaseRDF\Presentation\RDF\MappingRdfBuilder;
 use ProfessionalWiki\WikibaseRDF\EntryPoints\Rest\GetMappingsApi;
 use ProfessionalWiki\WikibaseRDF\EntryPoints\Rest\SaveMappingsApi;
+use ProfessionalWiki\WikibaseRDF\Presentation\RestSaveMappingsPresenter;
 use ProfessionalWiki\WikibaseRDF\Presentation\StubMappingsPresenter;
 use RequestContext;
 use User;
@@ -99,9 +103,6 @@ class WikibaseRdfExtension {
 	private function newSaveMappingsApi(): SaveMappingsApi {
 		return new SaveMappingsApi(
 			$this->newEntityIdParser(),
-			$this->newMappingRepository(
-				RequestContext::getMain()->getUser()
-			),
 			$this->newMappingListSerializer()
 		);
 	}
@@ -111,6 +112,21 @@ class WikibaseRdfExtension {
 	 */
 	private static function getAllowedPredicates(): array {
 		return (array)MediaWikiServices::getInstance()->getMainConfig()->get( 'WikibaseRdfPredicates' );
+	}
+
+	public function newSaveMappingsUseCase( SaveMappingsPresenter $presenter ): SaveMappingsUseCase {
+		return new SaveMappingsUseCase(
+			$presenter,
+			$this->newMappingRepository( RequestContext::getMain()->getUser() ),
+			self::getAllowedPredicates()
+		);
+	}
+
+	public function newRestSaveMappingsPresenter( ResponseFactory $responseFactory ): RestSaveMappingsPresenter {
+		return new RestSaveMappingsPresenter(
+			$responseFactory,
+			$this->newMappingListSerializer()
+		);
 	}
 
 }

--- a/tests/Application/SaveMappings/SaveMappingsUseCaseTest.php
+++ b/tests/Application/SaveMappings/SaveMappingsUseCaseTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\Application\SaveMappings;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseRDF\Application\Mapping;
+use ProfessionalWiki\WikibaseRDF\Application\MappingList;
+use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsUseCase;
+use ProfessionalWiki\WikibaseRDF\Persistence\InMemoryMappingRepository;
+use ProfessionalWiki\WikibaseRDF\Tests\TestDoubles\SpySaveMappingsPresenter;
+use ProfessionalWiki\WikibaseRDF\Tests\TestDoubles\ThrowingMappingRepository;
+use RuntimeException;
+use Wikibase\DataModel\Entity\ItemId;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsUseCase
+ */
+class SaveMappingsUseCaseTest extends TestCase {
+
+	private const VALID_PREDICATE = 'owl:sameAs';
+	private const INVALID_PREDICATE = 'invalid:predicate';
+	private const VALID_OBJECT = 'http://www.w3.org/2000/01/rdf-schema#subClassOf';
+
+	private SpySaveMappingsPresenter $presenter;
+	private InMemoryMappingRepository $repository;
+
+	public function setUp(): void {
+		$this->presenter = new SpySaveMappingsPresenter();
+		$this->repository = new InMemoryMappingRepository();
+	}
+
+	private function newUseCase(): SaveMappingsUseCase {
+		return new SaveMappingsUseCase(
+			$this->presenter,
+			$this->repository,
+			[ self::VALID_PREDICATE ]
+		);
+	}
+
+	private function newItemId(): ItemId {
+		return new ItemId( 'Q1' );
+	}
+
+	public function testShouldShowSuccess(): void {
+		$useCase = $this->newUseCase();
+
+		$useCase->saveMappings(
+			$this->newItemId(),
+			new MappingList( [
+				new Mapping( self::VALID_PREDICATE, self::VALID_OBJECT )
+			] )
+		);
+
+		$this->assertTrue( $this->presenter->showedSuccess );
+		$this->assertNull( $this->presenter->invalidMappings );
+		$this->assertFalse( $this->presenter->showedSaveFailed );
+	}
+
+	public function testMappingIsPersisted(): void {
+		$useCase = $this->newUseCase();
+		$entityId = $this->newItemId();
+
+		$useCase->saveMappings(
+			$entityId,
+			new MappingList( [
+				new Mapping( self::VALID_PREDICATE, self::VALID_OBJECT )
+			] )
+		);
+
+		$mappings = $this->repository->getMappings( $entityId );
+
+		$this->assertSame(
+			self::VALID_PREDICATE,
+			$mappings->asArray()[0]->predicate
+		);
+		$this->assertSame(
+			self::VALID_OBJECT,
+			$mappings->asArray()[0]->object
+		);
+	}
+
+	public function testShouldShowInvalidMappings(): void {
+		$useCase = $this->newUseCase();
+
+		$useCase->saveMappings(
+			$this->newItemId(),
+			new MappingList( [
+				new Mapping( self::VALID_PREDICATE, self::VALID_OBJECT ),
+				new Mapping( self::INVALID_PREDICATE, self::VALID_OBJECT )
+			] )
+		);
+
+		$this->assertFalse( $this->presenter->showedSuccess );
+		$this->assertSame(
+			self::INVALID_PREDICATE,
+			$this->presenter->invalidMappings->asArray()[0]->predicate
+		);
+		$this->assertSame(
+			self::VALID_OBJECT,
+			$this->presenter->invalidMappings->asArray()[0]->object
+		);
+		$this->assertFalse( $this->presenter->showedSaveFailed );
+	}
+
+	public function testShouldShowSaveFailed(): void {
+		$useCase = new SaveMappingsUseCase(
+			$this->presenter,
+			new ThrowingMappingRepository(),
+			[ self::VALID_PREDICATE ]
+		);
+
+		$useCase->saveMappings(
+			$this->newItemId(),
+			new MappingList( [
+				new Mapping( self::VALID_PREDICATE, self::VALID_OBJECT )
+			] )
+		);
+
+		$this->assertFalse( $this->presenter->showedSuccess );
+		$this->assertNull( $this->presenter->invalidMappings );
+		$this->assertTrue( $this->presenter->showedSaveFailed );
+	}
+
+}

--- a/tests/EntryPoints/Rest/GetMappingsApiTest.php
+++ b/tests/EntryPoints/Rest/GetMappingsApiTest.php
@@ -22,6 +22,7 @@ class GetMappingsApiTest extends MediaWikiIntegrationTestCase {
 			new RequestData( [ 'pathParams' => [ 'entity_id' => 'Q1' ] ] )
 		);
 
+		$this->assertSame( 200, $response->getStatusCode() );
 		$this->assertSame( 'application/json', $response->getHeaderLine( 'Content-Type' ) );
 
 		$data = json_decode( $response->getBody()->getContents(), true );

--- a/tests/Presentation/StubMappingsPresenterTest.php
+++ b/tests/Presentation/StubMappingsPresenterTest.php
@@ -1,5 +1,9 @@
 <?php
 
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\Presentation;
+
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\WikibaseRDF\Application\Mapping;
 use ProfessionalWiki\WikibaseRDF\Application\MappingList;

--- a/tests/TestDoubles/SpySaveMappingsPresenter.php
+++ b/tests/TestDoubles/SpySaveMappingsPresenter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\TestDoubles;
+
+use ProfessionalWiki\WikibaseRDF\Application\MappingList;
+use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsPresenter;
+
+class SpySaveMappingsPresenter implements SaveMappingsPresenter {
+
+	public bool $showedSuccess = false;
+	public ?MappingList $invalidMappings = null;
+	public bool $showedSaveFailed = false;
+
+	public function presentSuccess(): void {
+		$this->showedSuccess = true;
+	}
+
+	public function presentInvalidMappings( MappingList $mappings ): void {
+		$this->invalidMappings = $mappings;
+	}
+
+	public function presentSaveFailed(): void {
+		$this->showedSaveFailed = true;
+	}
+
+}

--- a/tests/TestDoubles/ThrowingMappingRepository.php
+++ b/tests/TestDoubles/ThrowingMappingRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\TestDoubles;
+
+use ProfessionalWiki\WikibaseRDF\Application\MappingList;
+use ProfessionalWiki\WikibaseRDF\Application\MappingRepository;
+use RuntimeException;
+use Wikibase\DataModel\Entity\EntityId;
+
+class ThrowingMappingRepository implements MappingRepository {
+
+	public function getMappings( EntityId $entityId ): MappingList {
+		throw new RuntimeException();
+	}
+
+	public function setMappings( EntityId $entityId, MappingList $mappingList ): void {
+		throw new RuntimeException();
+	}
+
+}


### PR DESCRIPTION
Primarily part of #33
Follow up to #38/#27 by adding allowed predicate validation and failure response.

Some comments below.