### PR TITLE
Refactor use case and Save API validation

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -16,7 +16,7 @@
 	"wikibase-rdf-mappings-action-edit": "edit",
 	"wikibase-rdf-mappings-action-add": "add mapping",
 
-	"wikibase-rdf-save-mappings-invalid-mappings": "Cannot save invalid mappings",
+	"wikibase-rdf-save-mappings-invalid-mappings": "Some of the mappings you specified are invalid",
 	"wikibase-rdf-save-mappings-save-failed": "Save failed",
 	"wikibase-rdf-entity-id-invalid": "The entity ID you specified is invalid"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -17,5 +17,6 @@
 	"wikibase-rdf-mappings-action-add": "add mapping",
 
 	"wikibase-rdf-save-mappings-invalid-mappings": "Cannot save invalid mappings",
-	"wikibase-rdf-save-mappings-save-failed": "Save failed"
+	"wikibase-rdf-save-mappings-save-failed": "Save failed",
+	"wikibase-rdf-entity-id-invalid": "The entity ID you specified is invalid"
 }

--- a/src/Application/SaveMappings/SaveMappingsPresenter.php
+++ b/src/Application/SaveMappings/SaveMappingsPresenter.php
@@ -14,4 +14,6 @@ interface SaveMappingsPresenter {
 
 	public function presentSaveFailed(): void;
 
+	public function presentInvalidEntityId(): void;
+
 }

--- a/src/Application/SaveMappings/SaveMappingsPresenter.php
+++ b/src/Application/SaveMappings/SaveMappingsPresenter.php
@@ -4,13 +4,14 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\Application\SaveMappings;
 
-use ProfessionalWiki\WikibaseRDF\Application\MappingList;
-
 interface SaveMappingsPresenter {
 
 	public function presentSuccess(): void;
 
-	public function presentInvalidMappings( MappingList $mappings ): void;
+	/**
+	 * @param array<int, array{predicate: string, object: string}> $mappings
+	 */
+	public function presentInvalidMappings( array $mappings ): void;
 
 	public function presentSaveFailed(): void;
 

--- a/src/Application/SaveMappings/SaveMappingsUseCase.php
+++ b/src/Application/SaveMappings/SaveMappingsUseCase.php
@@ -31,16 +31,15 @@ class SaveMappingsUseCase {
 		try {
 			$entityId = $this->entityIdParser->parse( $entityIdValue );
 		} catch ( EntityIdParsingException ) {
-			// TODO: $this->presenter->presentInvalidEntityId()
+			$this->presenter->presentInvalidEntityId();
 			return;
 		}
-
-		// TODO: check if $entityId exists
 
 		try {
 			$mappings = $this->mappingListSerializer->fromJson( $mappingsJson );
 		} catch ( InvalidArgumentException ) {
-			// TODO: present invalid predicates where the Mapping constructor fails
+			// TODO: get the actual invalid items
+			$this->presenter->presentInvalidMappings( new MappingList() );
 			return;
 		}
 

--- a/src/Application/SaveMappings/SaveMappingsUseCase.php
+++ b/src/Application/SaveMappings/SaveMappingsUseCase.php
@@ -5,8 +5,6 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseRDF\Application\SaveMappings;
 
 use InvalidArgumentException;
-use ProfessionalWiki\WikibaseRDF\Application\Mapping;
-use ProfessionalWiki\WikibaseRDF\Application\MappingList;
 use ProfessionalWiki\WikibaseRDF\Application\MappingRepository;
 use ProfessionalWiki\WikibaseRDF\MappingListSerializer;
 use Throwable;
@@ -14,6 +12,9 @@ use Wikibase\DataModel\Entity\EntityIdParser;
 use Wikibase\DataModel\Entity\EntityIdParsingException;
 
 class SaveMappingsUseCase {
+
+	private const PREDICATE_KEY = 'predicate';
+	private const OBJECT_KEY = 'object';
 
 	/**
 	 * @param string[] $allowedPredicates
@@ -27,7 +28,10 @@ class SaveMappingsUseCase {
 	) {
 	}
 
-	public function saveMappings( string $entityIdValue, string $mappingsJson ): void {
+	/**
+	 * @param array<mixed> $mappingsRequest
+	 */
+	public function saveMappings( string $entityIdValue, array $mappingsRequest ): void {
 		try {
 			$entityId = $this->entityIdParser->parse( $entityIdValue );
 		} catch ( EntityIdParsingException ) {
@@ -35,20 +39,20 @@ class SaveMappingsUseCase {
 			return;
 		}
 
-		try {
-			$mappings = $this->mappingListSerializer->fromJson( $mappingsJson );
-		} catch ( InvalidArgumentException ) {
-			// TODO: get the actual invalid items
-			$this->presenter->presentInvalidMappings( new MappingList() );
+		if ( !$this->mappingsIsList( $mappingsRequest ) ) {
+			$this->presenter->presentInvalidMappings( [] );
 			return;
 		}
 
-		// TODO: "invalid" is too generic here. We have malformed predicates, disallowed predicates and invalid objects.
-		$invalidMappings = $this->getInvalidMappings( $mappings );
-		if ( $invalidMappings->asArray() !== [] ) {
+		$normalizedMappings = $this->normalizeMappings( $mappingsRequest );
+
+		$invalidMappings = $this->getInvalidMappings( $normalizedMappings );
+		if ( $invalidMappings !== [] ) {
 			$this->presenter->presentInvalidMappings( $invalidMappings );
 			return;
 		}
+
+		$mappings = $this->mappingListSerializer->mappingListFromArray( $normalizedMappings );
 
 		try {
 			$this->repository->setMappings( $entityId, $mappings );
@@ -58,13 +62,53 @@ class SaveMappingsUseCase {
 		}
 	}
 
-	private function getInvalidMappings( MappingList $mappings ): MappingList {
-		return new MappingList(
+	/**
+	 * @param array<mixed> $mappings
+	 */
+	private function mappingsIsList( array $mappings ): bool {
+		return count( array_filter( array_keys( $mappings ), 'is_string' ) ) === 0;
+	}
+
+	/**
+	 * @param array<mixed> $mappings
+	 *
+	 * @return array<int, array{predicate: string, object: string}>
+	 */
+	private function normalizeMappings( array $mappings ): array {
+		$normalized = [];
+		foreach ( $mappings as $mapping ) {
+			if ( !is_array( $mapping ) ) {
+				$normalized[] = [ 'predicate' => '', 'object' => '' ];
+				continue;
+			}
+			$normalized[] = [
+				self::PREDICATE_KEY  => (string)( $mapping[self::PREDICATE_KEY] ?? '' ),
+				self::OBJECT_KEY => (string)( $mapping[self::OBJECT_KEY] ?? '' ),
+			];
+		}
+		return $normalized;
+	}
+
+	/**
+	 * @param array<int, array{predicate: string, object: string}> $mappings
+	 *
+	 * @return array<int, array{predicate: string, object: string}>
+	 */
+	private function getInvalidMappings( array $mappings ): array {
+		// TOOD: we might want to keep the original index to quickly identify the row when getting this in the UI JS.
+		return array_values(
 			array_filter(
-				$mappings->asArray(),
-				fn( Mapping $mapping ) => !in_array( $mapping->predicate, $this->allowedPredicates )
+				$mappings,
+				fn( array $mapping ) => !$this->mappingIsValid( $mapping[self::PREDICATE_KEY], $mapping[self::OBJECT_KEY] )
 			)
 		);
+	}
+
+	private function mappingIsValid( string $predicate, string $object ): bool {
+		return $predicate !== ''
+			&& $object !== ''
+			&& str_contains( $predicate, ':' )
+			&& in_array( $predicate, $this->allowedPredicates );
 	}
 
 }

--- a/src/EntryPoints/Rest/SaveMappingsApi.php
+++ b/src/EntryPoints/Rest/SaveMappingsApi.php
@@ -19,7 +19,7 @@ class SaveMappingsApi extends SimpleHandler {
 
 		$presenter = WikibaseRdfExtension::getInstance()->newRestSaveMappingsPresenter( $this->getResponseFactory() );
 		$useCase = WikibaseRdfExtension::getInstance()->newSaveMappingsUseCase( $presenter );
-		$useCase->saveMappings( $entityId, $body );
+		$useCase->saveMappings( $entityId, (array)json_decode( $body, true ) );
 
 		return $presenter->getResponse();
 	}

--- a/src/EntryPoints/Rest/SaveMappingsApi.php
+++ b/src/EntryPoints/Rest/SaveMappingsApi.php
@@ -15,11 +15,9 @@ use Wikimedia\ParamValidator\ParamValidator;
 class SaveMappingsApi extends SimpleHandler {
 
 	public function run( string $entityId ): Response {
-		$body = $this->getRequest()->getBody()->getContents();
-
 		$presenter = WikibaseRdfExtension::getInstance()->newRestSaveMappingsPresenter( $this->getResponseFactory() );
 		$useCase = WikibaseRdfExtension::getInstance()->newSaveMappingsUseCase( $presenter );
-		$useCase->saveMappings( $entityId, (array)json_decode( $body, true ) );
+		$useCase->saveMappings( $entityId, (array)$this->getValidatedBody() );
 
 		return $presenter->getResponse();
 	}

--- a/src/EntryPoints/Rest/SaveMappingsApi.php
+++ b/src/EntryPoints/Rest/SaveMappingsApi.php
@@ -9,27 +9,17 @@ use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
 use MediaWiki\Rest\Validator\BodyValidator;
 use MediaWiki\Rest\Validator\JsonBodyValidator;
-use ProfessionalWiki\WikibaseRDF\MappingListSerializer;
 use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
-use Wikibase\DataModel\Entity\EntityId;
-use Wikibase\DataModel\Entity\EntityIdParser;
 use Wikimedia\ParamValidator\ParamValidator;
 
 class SaveMappingsApi extends SimpleHandler {
 
-	public function __construct(
-		private EntityIdParser $entityIdParser,
-		private MappingListSerializer $mappingListSerializer
-	) {
-	}
-
 	public function run( string $entityId ): Response {
 		$body = $this->getRequest()->getBody()->getContents();
-		$mappings = $this->mappingListSerializer->fromJson( $body );
 
 		$presenter = WikibaseRdfExtension::getInstance()->newRestSaveMappingsPresenter( $this->getResponseFactory() );
 		$useCase = WikibaseRdfExtension::getInstance()->newSaveMappingsUseCase( $presenter );
-		$useCase->saveMappings( $this->getEntityId( $entityId ), $mappings );
+		$useCase->saveMappings( $entityId, $body );
 
 		return $presenter->getResponse();
 	}
@@ -60,12 +50,7 @@ class SaveMappingsApi extends SimpleHandler {
 			);
 		}
 
-		// TODO: Can we validate the Mapping fields here?
 		return new JsonBodyValidator( [] );
-	}
-
-	private function getEntityId( string $entityId ): EntityId {
-		return $this->entityIdParser->parse( $entityId );
 	}
 
 }

--- a/src/MappingListSerializer.php
+++ b/src/MappingListSerializer.php
@@ -25,7 +25,7 @@ class MappingListSerializer {
 	/**
 	 * @param array<int, array{predicate: string, object: string}> $mappings
 	 */
-	private function mappingListFromArray( array $mappings ): MappingList {
+	public function mappingListFromArray( array $mappings ): MappingList {
 		return new MappingList(
 			array_map(
 				fn( array $mapping ) => new Mapping(

--- a/src/Presentation/RestSaveMappingsPresenter.php
+++ b/src/Presentation/RestSaveMappingsPresenter.php
@@ -40,6 +40,13 @@ class RestSaveMappingsPresenter implements SaveMappingsPresenter {
 		);
 	}
 
+	public function presentInvalidEntityId(): void {
+		$this->response = $this->responseFactory->createLocalizedHttpError(
+			400,
+			MessageValue::new( 'wikibase-rdf-entity-id-invalid' ),
+		);
+	}
+
 	public function getResponse(): Response {
 		return $this->response;
 	}

--- a/src/Presentation/RestSaveMappingsPresenter.php
+++ b/src/Presentation/RestSaveMappingsPresenter.php
@@ -16,8 +16,7 @@ class RestSaveMappingsPresenter implements SaveMappingsPresenter {
 	private Response $response;
 
 	public function __construct(
-		private ResponseFactory $responseFactory,
-		private MappingListSerializer $mappingListSerializer
+		private ResponseFactory $responseFactory
 	) {
 	}
 
@@ -25,11 +24,11 @@ class RestSaveMappingsPresenter implements SaveMappingsPresenter {
 		$this->response = $this->responseFactory->createNoContent();
 	}
 
-	public function presentInvalidMappings( MappingList $mappings ): void {
+	public function presentInvalidMappings( array $mappings ): void {
 		$this->response = $this->responseFactory->createLocalizedHttpError(
 			400,
 			MessageValue::new( 'wikibase-rdf-save-mappings-invalid-mappings' ),
-			[ 'invalidMappings' => $this->mappingListSerializer->mappingListToArray( $mappings ) ]
+			[ 'invalidMappings' => $mappings ]
 		);
 	}
 

--- a/src/WikibaseRdfExtension.php
+++ b/src/WikibaseRdfExtension.php
@@ -105,10 +105,7 @@ class WikibaseRdfExtension {
 	}
 
 	private function newSaveMappingsApi(): SaveMappingsApi {
-		return new SaveMappingsApi(
-			$this->newEntityIdParser(),
-			$this->newMappingListSerializer()
-		);
+		return new SaveMappingsApi();
 	}
 
 	public static function getAllMappingsApiFactory(): GetAllMappingsApi {
@@ -142,7 +139,9 @@ class WikibaseRdfExtension {
 		return new SaveMappingsUseCase(
 			$presenter,
 			$this->newMappingRepository( RequestContext::getMain()->getUser() ),
-			self::getAllowedPredicates()
+			self::getAllowedPredicates(),
+			$this->newEntityIdParser(),
+			$this->newMappingListSerializer()
 		);
 	}
 

--- a/src/WikibaseRdfExtension.php
+++ b/src/WikibaseRdfExtension.php
@@ -147,8 +147,7 @@ class WikibaseRdfExtension {
 
 	public function newRestSaveMappingsPresenter( ResponseFactory $responseFactory ): RestSaveMappingsPresenter {
 		return new RestSaveMappingsPresenter(
-			$responseFactory,
-			$this->newMappingListSerializer()
+			$responseFactory
 		);
 	}
 

--- a/tests/Application/SaveMappings/SaveMappingsUseCaseTest.php
+++ b/tests/Application/SaveMappings/SaveMappingsUseCaseTest.php
@@ -40,10 +40,6 @@ class SaveMappingsUseCaseTest extends TestCase {
 		);
 	}
 
-	private function newItemId(): ItemId {
-		return new ItemId( 'Q1' );
-	}
-
 	public function testShouldShowSuccess(): void {
 		$useCase = $this->newUseCase();
 
@@ -117,6 +113,23 @@ class SaveMappingsUseCaseTest extends TestCase {
 		$this->assertFalse( $this->presenter->showedSuccess );
 		$this->assertNull( $this->presenter->invalidMappings );
 		$this->assertTrue( $this->presenter->showedSaveFailed );
+	}
+
+	public function testShouldShowInvalidEntityId(): void {
+		$useCase = new SaveMappingsUseCase(
+			$this->presenter,
+			new ThrowingMappingRepository(),
+			[ self::VALID_PREDICATE ],
+			new BasicEntityIdParser(),
+			new MappingListSerializer()
+		);
+
+		$useCase->saveMappings(
+			'NotId',
+			'[{"predicate": "' . self::VALID_PREDICATE . '", "object": "' . self::VALID_OBJECT . '"}]'
+		);
+
+		$this->assertTrue( $this->presenter->showedInvalidEntityId );
 	}
 
 }

--- a/tests/Application/SaveMappings/SaveMappingsUseCaseTest.php
+++ b/tests/Application/SaveMappings/SaveMappingsUseCaseTest.php
@@ -45,11 +45,13 @@ class SaveMappingsUseCaseTest extends TestCase {
 
 		$useCase->saveMappings(
 			'Q1',
-			'[{"predicate": "' . self::VALID_PREDICATE . '", "object": "' . self::VALID_OBJECT . '"}]'
+			[
+				[ 'predicate' => self::VALID_PREDICATE, 'object' => self::VALID_OBJECT ]
+			]
 		);
 
 		$this->assertTrue( $this->presenter->showedSuccess );
-		$this->assertNull( $this->presenter->invalidMappings );
+		$this->assertSame( [], $this->presenter->invalidMappings );
 		$this->assertFalse( $this->presenter->showedSaveFailed );
 	}
 
@@ -58,7 +60,9 @@ class SaveMappingsUseCaseTest extends TestCase {
 
 		$useCase->saveMappings(
 			'Q2',
-			'[{"predicate": "' . self::VALID_PREDICATE . '", "object": "' . self::VALID_OBJECT . '"}]'
+			[
+				[ 'predicate' => self::VALID_PREDICATE, 'object' => self::VALID_OBJECT ]
+			]
 		);
 
 		$mappings = $this->repository->getMappings( new ItemId( 'Q2' ) );
@@ -78,20 +82,20 @@ class SaveMappingsUseCaseTest extends TestCase {
 
 		$useCase->saveMappings(
 			'Q3',
-			'[
-				{"predicate": "' . self::VALID_PREDICATE . '", "object": "' . self::VALID_OBJECT . '"},
-				{"predicate": "' . self::INVALID_PREDICATE . '", "object": "' . self::VALID_OBJECT . '"}
-			]'
+			[
+				[ 'predicate' => self::VALID_PREDICATE, 'object' => self::VALID_OBJECT ],
+				[ 'predicate' => self::INVALID_PREDICATE, 'object' => self::VALID_OBJECT ],
+			]
 		);
 
 		$this->assertFalse( $this->presenter->showedSuccess );
 		$this->assertSame(
 			self::INVALID_PREDICATE,
-			$this->presenter->invalidMappings->asArray()[0]->predicate
+			$this->presenter->invalidMappings[0]['predicate']
 		);
 		$this->assertSame(
 			self::VALID_OBJECT,
-			$this->presenter->invalidMappings->asArray()[0]->object
+			$this->presenter->invalidMappings[0]['object']
 		);
 		$this->assertFalse( $this->presenter->showedSaveFailed );
 	}
@@ -107,11 +111,13 @@ class SaveMappingsUseCaseTest extends TestCase {
 
 		$useCase->saveMappings(
 			'Q4',
-			'[{"predicate": "' . self::VALID_PREDICATE . '", "object": "' . self::VALID_OBJECT . '"}]'
+			[
+				[ 'predicate' => self::VALID_PREDICATE, 'object' => self::VALID_OBJECT ]
+			]
 		);
 
 		$this->assertFalse( $this->presenter->showedSuccess );
-		$this->assertNull( $this->presenter->invalidMappings );
+		$this->assertSame( [], $this->presenter->invalidMappings );
 		$this->assertTrue( $this->presenter->showedSaveFailed );
 	}
 
@@ -126,7 +132,9 @@ class SaveMappingsUseCaseTest extends TestCase {
 
 		$useCase->saveMappings(
 			'NotId',
-			'[{"predicate": "' . self::VALID_PREDICATE . '", "object": "' . self::VALID_OBJECT . '"}]'
+			[
+				[ 'predicate' => self::VALID_PREDICATE, 'object' => self::VALID_OBJECT ]
+			]
 		);
 
 		$this->assertTrue( $this->presenter->showedInvalidEntityId );

--- a/tests/EntryPoints/Rest/SaveMappingsApiTest.php
+++ b/tests/EntryPoints/Rest/SaveMappingsApiTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\Tests\Integration;
 
+use MediaWiki\Rest\LocalizedHttpException;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use ProfessionalWiki\WikibaseRDF\Tests\WikibaseRdfIntegrationTest;
@@ -41,7 +42,143 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 		$this->assertSame( 204, $response->getStatusCode() );
 	}
 
-	public function testMalformedPredicate(): void {
+	public function testJsonIsInvalid(): void {
+		$this->expectException( LocalizedHttpException::class );
+		$this->executeHandler(
+			WikibaseRdfExtension::saveMappingsApiFactory(),
+			new RequestData( [
+				'method' => 'POST',
+				'pathParams' => [ 'entity_id' => 'Q1' ],
+				'headers' => [ 'Content-Type' => 'application/json' ],
+				'bodyContents' => $this->createInvalidJsonBody()
+			] )
+		);
+	}
+
+	public function testJsonIsNotAList(): void {
+		$response = $this->executeHandler(
+			WikibaseRdfExtension::saveMappingsApiFactory(),
+			new RequestData( [
+				'method' => 'POST',
+				'pathParams' => [ 'entity_id' => 'Q1' ],
+				'headers' => [ 'Content-Type' => 'application/json' ],
+				'bodyContents' => $this->createNonArrayBody()
+			] )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertSame( 'application/json', $response->getHeaderLine( 'Content-Type' ) );
+
+		$data = json_decode( $response->getBody()->getContents(), true );
+		$this->assertIsArray( $data );
+
+		$this->assertArrayHasKey( 'invalidMappings', $data );
+		$this->assertSame(
+			[],
+			$data['invalidMappings']
+		);
+
+		$this->assertStringContainsString(
+			'wikibase-rdf-save-mappings-invalid-mappings',
+			$data['messageTranslations']['']
+		);
+	}
+
+	public function testMappingKeysAreInvalid(): void {
+		$response = $this->executeHandler(
+			WikibaseRdfExtension::saveMappingsApiFactory(),
+			new RequestData( [
+				'method' => 'POST',
+				'pathParams' => [ 'entity_id' => 'Q1' ],
+				'headers' => [ 'Content-Type' => 'application/json' ],
+				'bodyContents' => $this->createInvalidKeysBody()
+			] )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertSame( 'application/json', $response->getHeaderLine( 'Content-Type' ) );
+
+		$data = json_decode( $response->getBody()->getContents(), true );
+		$this->assertIsArray( $data );
+
+		$this->assertArrayHasKey( 'invalidMappings', $data );
+		// TODO: this might be useful if we include the original values, although that complicates the type hinting
+		$this->assertSame(
+			[
+				[ 'predicate' => '', 'object' => '' ]
+			],
+			$data['invalidMappings']
+		);
+
+		$this->assertStringContainsString(
+			'wikibase-rdf-save-mappings-invalid-mappings',
+			$data['messageTranslations']['']
+		);
+	}
+
+	public function testMappingPredicateIsMissing(): void {
+		$response = $this->executeHandler(
+			WikibaseRdfExtension::saveMappingsApiFactory(),
+			new RequestData( [
+				'method' => 'POST',
+				'pathParams' => [ 'entity_id' => 'Q1' ],
+				'headers' => [ 'Content-Type' => 'application/json' ],
+				'bodyContents' => $this->createMissingPredicateBody()
+			] )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertSame( 'application/json', $response->getHeaderLine( 'Content-Type' ) );
+
+		$data = json_decode( $response->getBody()->getContents(), true );
+		$this->assertIsArray( $data );
+
+		$this->assertArrayHasKey( 'invalidMappings', $data );
+		$this->assertSame(
+			[
+				[ 'predicate' => '', 'object' => 'owl:subClassOf' ]
+			],
+			$data['invalidMappings']
+		);
+
+		$this->assertStringContainsString(
+			'wikibase-rdf-save-mappings-invalid-mappings',
+			$data['messageTranslations']['']
+		);
+	}
+
+	public function testMappingObjectIsMissing(): void {
+		$response = $this->executeHandler(
+			WikibaseRdfExtension::saveMappingsApiFactory(),
+			new RequestData( [
+				'method' => 'POST',
+				'pathParams' => [ 'entity_id' => 'Q1' ],
+				'headers' => [ 'Content-Type' => 'application/json' ],
+				'bodyContents' => $this->createMissingObjectBody()
+			] )
+		);
+
+		$this->assertSame( 400, $response->getStatusCode() );
+		$this->assertSame( 'application/json', $response->getHeaderLine( 'Content-Type' ) );
+
+		$data = json_decode( $response->getBody()->getContents(), true );
+		$this->assertIsArray( $data );
+
+		$this->assertArrayHasKey( 'invalidMappings', $data );
+		$this->assertSame(
+			[
+				[ 'predicate' => 'owl:sameAs', 'object' => '' ]
+			],
+			$data['invalidMappings']
+		);
+
+		$this->assertStringContainsString(
+			'wikibase-rdf-save-mappings-invalid-mappings',
+			$data['messageTranslations']['']
+		);
+	}
+
+	public function testMappingPredicateIsMalformed(): void {
 		$response = $this->executeHandler(
 			WikibaseRdfExtension::saveMappingsApiFactory(),
 			new RequestData( [
@@ -61,20 +198,18 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 		$this->assertArrayHasKey( 'invalidMappings', $data );
 		$this->assertSame(
 			[
-				// TODO
-//				[ 'predicate' => 'owl-sameAs', 'object' => 'http://example.com' ]
+				[ 'predicate' => 'owl-sameAs', 'object' => 'http://example.com' ]
 			],
 			$data['invalidMappings']
 		);
 
-		// TODO: setup language codes in test and/or do we need to test this?
 		$this->assertStringContainsString(
 			'wikibase-rdf-save-mappings-invalid-mappings',
 			$data['messageTranslations']['']
 		);
 	}
 
-	public function testDisallowedPredicate(): void {
+	public function testMappingPredicateIsNotAllowed(): void {
 		$response = $this->executeHandler(
 			WikibaseRdfExtension::saveMappingsApiFactory(),
 			new RequestData( [
@@ -99,14 +234,13 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 			$data['invalidMappings']
 		);
 
-		// TODO: setup language codes in test and/or do we need to test this?
 		$this->assertStringContainsString(
 			'wikibase-rdf-save-mappings-invalid-mappings',
 			$data['messageTranslations']['']
 		);
 	}
 
-	public function testInvalidEntityId(): void {
+	public function testEntityIdIsInvalid(): void {
 		$response = $this->executeHandler(
 			WikibaseRdfExtension::saveMappingsApiFactory(),
 			new RequestData( [
@@ -123,14 +257,13 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 		$data = json_decode( $response->getBody()->getContents(), true );
 		$this->assertIsArray( $data );
 
-		// TODO: setup language codes in test and/or do we need to test this?
 		$this->assertStringContainsString(
 			'wikibase-rdf-entity-id-invalid',
 			$data['messageTranslations']['']
 		);
 	}
 
-	public function testMissingEntityId(): void {
+	public function testEntityDoesNotExist(): void {
 		$response = $this->executeHandler(
 			WikibaseRdfExtension::saveMappingsApiFactory(),
 			new RequestData( [
@@ -147,11 +280,24 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 		$data = json_decode( $response->getBody()->getContents(), true );
 		$this->assertIsArray( $data );
 
-		// TODO: setup language codes in test and/or do we need to test this?
 		$this->assertStringContainsString(
 			'wikibase-rdf-save-mappings-save-failed',
 			$data['messageTranslations']['']
 		);
+	}
+
+	public function testRemoveMappings(): void {
+		$response = $this->executeHandler(
+			WikibaseRdfExtension::saveMappingsApiFactory(),
+			new RequestData( [
+				'method' => 'PUT',
+				'pathParams' => [ 'entity_id' => 'Q1' ],
+				'headers' => [ 'Content-Type' => 'application/json' ],
+				'bodyContents' => $this->createRemoveMappingsBody()
+			] )
+		);
+
+		$this->assertSame( 204, $response->getStatusCode() );
 	}
 
 	public function testSaveFailed(): void {
@@ -162,6 +308,38 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 		return '[
 			{"predicate": "owl:sameAs", "object": "http://www.w3.org/2000/01/rdf-schema#subClassOf"},
 			{"predicate": "owl:sameAs", "object": "owl:subClassOf"}
+		]';
+	}
+
+	private function createInvalidJsonBody(): string {
+		return '
+			{"predicate": "owl:sameAs", "object": "http://www.w3.org/2000/01/rdf-schema#subClassOf"},
+			{"predicate": "owl:sameAs", "object": "owl:subClassOf"}
+		';
+	}
+
+	private function createNonArrayBody(): string {
+		return '{"predicate": "owl:sameAs", "object": "http://www.w3.org/2000/01/rdf-schema#subClassOf"}';
+	}
+
+	private function createInvalidKeysBody(): string {
+		return '[
+			{"predicate": "owl:sameAs", "object": "http://www.w3.org/2000/01/rdf-schema#subClassOf"},
+			{"foo": "owl:sameAs", "bar": "owl:subClassOf"}
+		]';
+	}
+
+	private function createMissingPredicateBody(): string {
+		return '[
+			{"predicate": "owl:sameAs", "object": "http://www.w3.org/2000/01/rdf-schema#subClassOf"},
+			{"object": "owl:subClassOf"}
+		]';
+	}
+
+	private function createMissingObjectBody(): string {
+		return '[
+			{"predicate": "owl:sameAs", "object": "http://www.w3.org/2000/01/rdf-schema#subClassOf"},
+			{"predicate": "owl:sameAs"}
 		]';
 	}
 
@@ -177,6 +355,10 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 			{"predicate": "owl:sameAs", "object": "http://www.w3.org/2000/01/rdf-schema#subClassOf"},
 			{"predicate": "foo:bar", "object": "http://example.com"}
 		]';
+	}
+
+	private function createRemoveMappingsBody(): string {
+		return '[]';
 	}
 
 }

--- a/tests/Persistence/SqlAllMappingsLookupTest.php
+++ b/tests/Persistence/SqlAllMappingsLookupTest.php
@@ -26,13 +26,6 @@ class SqlAllMappingsLookupTest extends WikibaseRdfIntegrationTest {
 		$this->setAllowedPredicates( [ 'foo:foo', 'foo:bar', 'foo:baz' ] );
 	}
 
-	/**
-	 * @param string[] $predicates
-	 */
-	private function setAllowedPredicates( array $predicates ): void {
-		$this->setMwGlobals( 'wgWikibaseRdfPredicates', $predicates );
-	}
-
 	private function newSqlAllMappingsLookup(): SqlAllMappingsLookup {
 		return new SqlAllMappingsLookup(
 			$this->db,

--- a/tests/TestDoubles/SpySaveMappingsPresenter.php
+++ b/tests/TestDoubles/SpySaveMappingsPresenter.php
@@ -10,7 +10,8 @@ use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsPresenter;
 class SpySaveMappingsPresenter implements SaveMappingsPresenter {
 
 	public bool $showedSuccess = false;
-	public ?MappingList $invalidMappings = null;
+	/** @var array<int, array{predicate: string, object: string}> */
+	public array $invalidMappings = [];
 	public bool $showedSaveFailed = false;
 	public bool $showedInvalidEntityId = false;
 
@@ -18,7 +19,10 @@ class SpySaveMappingsPresenter implements SaveMappingsPresenter {
 		$this->showedSuccess = true;
 	}
 
-	public function presentInvalidMappings( MappingList $mappings ): void {
+	/**
+	 * @param array<int, array{predicate: string, object: string}> $mappings
+	 */
+	public function presentInvalidMappings( array $mappings ): void {
 		$this->invalidMappings = $mappings;
 	}
 

--- a/tests/TestDoubles/SpySaveMappingsPresenter.php
+++ b/tests/TestDoubles/SpySaveMappingsPresenter.php
@@ -12,6 +12,7 @@ class SpySaveMappingsPresenter implements SaveMappingsPresenter {
 	public bool $showedSuccess = false;
 	public ?MappingList $invalidMappings = null;
 	public bool $showedSaveFailed = false;
+	public bool $showedInvalidEntityId = false;
 
 	public function presentSuccess(): void {
 		$this->showedSuccess = true;
@@ -23,6 +24,10 @@ class SpySaveMappingsPresenter implements SaveMappingsPresenter {
 
 	public function presentSaveFailed(): void {
 		$this->showedSaveFailed = true;
+	}
+
+	public function presentInvalidEntityId(): void {
+		$this->showedInvalidEntityId = true;
 	}
 
 }

--- a/tests/WikibaseRdfIntegrationTest.php
+++ b/tests/WikibaseRdfIntegrationTest.php
@@ -78,4 +78,11 @@ class WikibaseRdfIntegrationTest extends MediaWikiIntegrationTestCase {
 		$this->saveItem( $item );
 	}
 
+	/**
+	 * @param string[] $predicates
+	 */
+	protected function setAllowedPredicates( array $predicates ): void {
+		$this->setMwGlobals( 'wgWikibaseRdfPredicates', $predicates );
+	}
+
 }


### PR DESCRIPTION
From https://github.com/ProfessionalWiki/WikibaseRDF/pull/46#discussion_r930147474 and part of #31 

Is my understanding of that correct here?
* `SaveMappingsApi` validates:
  * Entity ID string is in the URL
  * Payload contains well-formed Json
* The UC validates:
  * Entity ID is valid
  * Entity ID exists
  * Mapping predicates are well-formed
  * Mapping predicates are in the allowed list
  * Mapping object values