### PR TITLE
Add lookup tables

### DIFF
--- a/src/MappingListSerializer.php
+++ b/src/MappingListSerializer.php
@@ -26,21 +26,15 @@ class MappingListSerializer {
 	 * @param array<int, array{predicate: string, object: string}> $mappings
 	 */
 	private function mappingListFromArray( array $mappings ): MappingList {
-		try {
-			return new MappingList(
-				array_map(
-					fn( array $mapping ) => new Mapping(
-						predicate: $mapping[self::PREDICATE_KEY],
-						object: $mapping[self::OBJECT_KEY]
-					),
-					$mappings
-				)
-			);
-		}
-		catch ( \Throwable ) {
-			var_dump($mappings);exit;
-//			return new MappingList();
-		}
+		return new MappingList(
+			array_map(
+				fn( array $mapping ) => new Mapping(
+					predicate: $mapping[self::PREDICATE_KEY],
+					object: $mapping[self::OBJECT_KEY]
+				),
+				$mappings
+			)
+		);
 	}
 
 	public function toJson( MappingList $mappingList ): string {

--- a/tests/WikibaseRdfIntegrationTest.php
+++ b/tests/WikibaseRdfIntegrationTest.php
@@ -19,6 +19,9 @@ class WikibaseRdfIntegrationTest extends MediaWikiIntegrationTestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
+		$this->tablesUsed[] = 'text';
+		$this->tablesUsed[] = 'slots';
+		$this->tablesUsed[] = 'slot_roles';
 		$this->tablesUsed[] = 'page';
 	}
 


### PR DESCRIPTION
From https://github.com/ProfessionalWiki/WikibaseRDF/pull/56#discussion_r933858751

Doing this as a separate branch/PR to figure out what's going on.

When only the one table (or none) is specified it seems to cause the issue with the wrong slot content being deserialized. With all the tables used in the query it no longer picks up the wrong rows.

Not sure if this means there's a chance the query might in some theoretical circumstance get the wrong data, or if the test environment DB setup was messing this up.