### PR TITLE
Add simple CSS to block actions

### DIFF
--- a/resources/ext.wikibase.rdf.js
+++ b/resources/ext.wikibase.rdf.js
@@ -75,8 +75,20 @@ $( function () {
 		findRow( trigger ).remove();
 	}
 
+	function disableActions() {
+		console.log( 'disableActions' );
+		$( '#wikibase-rdf' ).addClass( 'wikibase-rdf-disabled' );
+	}
+
+	function enableActions() {
+		console.log( 'enableActions' );
+		$( '#wikibase-rdf' ).removeClass( 'wikibase-rdf-disabled' );
+	}
+
 	function saveMappings( trigger ) {
 		console.log( 'saveMappings' );
+		disableActions();
+
 		const mappings = [];
 
 		findRow( trigger ).addClass( 'wikibase-rdf-row-editing-saving' );
@@ -122,9 +134,11 @@ $( function () {
 				} else if ( isRemove ) {
 					onSuccessfulRemove( trigger );
 				}
+				enableActions();
 			} )
 			.fail( function ( data, response ) {
 				showError( response.xhr.responseJSON );
+				enableActions();
 			} );
 	}
 

--- a/resources/ext.wikibase.rdf.less
+++ b/resources/ext.wikibase.rdf.less
@@ -39,6 +39,11 @@
 	color: @color-destructive;
 }
 
+.wikibase-rdf-disabled a {
+	pointer-events: none;
+	color: unset;
+}
+
 .wikibase-rdf-row {
 	display: flex;
 	width: 100%;


### PR DESCRIPTION
Refs #60

Quick CSS solution to block click actions when Save/Remove is clicked. It prevents clicks and removes the link color:
![Screenshot_20220805_162035](https://user-images.githubusercontent.com/1428594/183096734-daa88f66-d2b6-446e-985e-7910a108a4ee.png)

For now this is primarily to prevent rapid (almost) concurrent Save/Remove clicks. When saving only a few mappings this is very quick so the disabling and color change is very brief. If we find a point where saving is too slow then we can add additional UI indicators (e.g. "Saving..." or a spinner).