### PR TITLE
Add Save Mappings API permission check

### DIFF
--- a/src/Application/MappingRepository.php
+++ b/src/Application/MappingRepository.php
@@ -4,12 +4,16 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\Application;
 
+use PermissionsError;
 use Wikibase\DataModel\Entity\EntityId;
 
 interface MappingRepository {
 
 	public function getMappings( EntityId $entityId ): MappingList;
 
+	/**
+	 * @throws PermissionsError
+	 */
 	public function setMappings( EntityId $entityId, MappingList $mappingList ): void;
 
 }

--- a/src/Application/SaveMappings/SaveMappingsPresenter.php
+++ b/src/Application/SaveMappings/SaveMappingsPresenter.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\Application\SaveMappings;
 
+use Throwable;
+
 interface SaveMappingsPresenter {
 
 	public function presentSuccess(): void;
@@ -16,5 +18,7 @@ interface SaveMappingsPresenter {
 	public function presentSaveFailed(): void;
 
 	public function presentInvalidEntityId(): void;
+
+	public function presentPermissionDenied( Throwable $exception ): void;
 
 }

--- a/src/Application/SaveMappings/SaveMappingsUseCase.php
+++ b/src/Application/SaveMappings/SaveMappingsUseCase.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\Application\SaveMappings;
 
-use InvalidArgumentException;
+use PermissionsError;
 use ProfessionalWiki\WikibaseRDF\Application\MappingRepository;
 use ProfessionalWiki\WikibaseRDF\MappingListSerializer;
 use Throwable;
@@ -57,6 +57,8 @@ class SaveMappingsUseCase {
 		try {
 			$this->repository->setMappings( $entityId, $mappings );
 			$this->presenter->presentSuccess();
+		} catch ( PermissionsError $exception ) {
+			$this->presenter->presentPermissionDenied( $exception );
 		} catch ( Throwable ) {
 			$this->presenter->presentSaveFailed();
 		}

--- a/src/EntryPoints/Rest/SaveMappingsApi.php
+++ b/src/EntryPoints/Rest/SaveMappingsApi.php
@@ -16,7 +16,7 @@ class SaveMappingsApi extends SimpleHandler {
 
 	public function run( string $entityId ): Response {
 		$presenter = WikibaseRdfExtension::getInstance()->newRestSaveMappingsPresenter( $this->getResponseFactory() );
-		$useCase = WikibaseRdfExtension::getInstance()->newSaveMappingsUseCase( $presenter );
+		$useCase = WikibaseRdfExtension::getInstance()->newSaveMappingsUseCase( $presenter, $this->getAuthority() );
 		$useCase->saveMappings( $entityId, (array)$this->getValidatedBody() );
 
 		return $presenter->getResponse();

--- a/src/Persistence/EntityContentRepository.php
+++ b/src/Persistence/EntityContentRepository.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\WikibaseRDF\Persistence;
 
 use Content;
 use Exception;
+use PermissionsError;
 use Wikibase\DataModel\Entity\EntityId;
 
 /**
@@ -17,6 +18,7 @@ interface EntityContentRepository {
 
 	/**
 	 * @throws Exception
+	 * @throws PermissionsError
 	 */
 	public function setContent( EntityId $entityId, Content $content ): void;
 

--- a/src/Presentation/RestSaveMappingsPresenter.php
+++ b/src/Presentation/RestSaveMappingsPresenter.php
@@ -6,9 +6,8 @@ namespace ProfessionalWiki\WikibaseRDF\Presentation;
 
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\ResponseFactory;
-use ProfessionalWiki\WikibaseRDF\Application\MappingList;
 use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsPresenter;
-use ProfessionalWiki\WikibaseRDF\MappingListSerializer;
+use Throwable;
 use Wikimedia\Message\MessageValue;
 
 class RestSaveMappingsPresenter implements SaveMappingsPresenter {
@@ -43,6 +42,13 @@ class RestSaveMappingsPresenter implements SaveMappingsPresenter {
 		$this->response = $this->responseFactory->createLocalizedHttpError(
 			400,
 			MessageValue::new( 'wikibase-rdf-entity-id-invalid' ),
+		);
+	}
+
+	public function presentPermissionDenied( Throwable $exception ): void {
+		$this->response = $this->responseFactory->createHttpError(
+			403,
+			[ 'message' => $exception->getMessage() ]
 		);
 	}
 

--- a/tests/Application/SaveMappings/SaveMappingsUseCaseTest.php
+++ b/tests/Application/SaveMappings/SaveMappingsUseCaseTest.php
@@ -4,10 +4,12 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\Tests\Application\SaveMappings;
 
+use PermissionsError;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsUseCase;
 use ProfessionalWiki\WikibaseRDF\MappingListSerializer;
 use ProfessionalWiki\WikibaseRDF\Persistence\InMemoryMappingRepository;
+use ProfessionalWiki\WikibaseRDF\Tests\TestDoubles\PermissionDeniedMappingRepository;
 use ProfessionalWiki\WikibaseRDF\Tests\TestDoubles\SpySaveMappingsPresenter;
 use ProfessionalWiki\WikibaseRDF\Tests\TestDoubles\ThrowingMappingRepository;
 use Wikibase\DataModel\Entity\BasicEntityIdParser;
@@ -138,6 +140,28 @@ class SaveMappingsUseCaseTest extends TestCase {
 		);
 
 		$this->assertTrue( $this->presenter->showedInvalidEntityId );
+	}
+
+	public function testShouldShowPermissionDenied(): void {
+		$useCase = new SaveMappingsUseCase(
+			$this->presenter,
+			new PermissionDeniedMappingRepository(),
+			[ self::VALID_PREDICATE ],
+			new BasicEntityIdParser(),
+			new MappingListSerializer()
+		);
+
+		$useCase->saveMappings(
+			'Q1',
+			[
+				[ 'predicate' => self::VALID_PREDICATE, 'object' => self::VALID_OBJECT ]
+			]
+		);
+
+		$this->assertEquals(
+			new PermissionsError( 'edit' ),
+			$this->presenter->permissionDeniedException
+		);
 	}
 
 }

--- a/tests/TestDoubles/PermissionDeniedMappingRepository.php
+++ b/tests/TestDoubles/PermissionDeniedMappingRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\TestDoubles;
+
+use PermissionsError;
+use ProfessionalWiki\WikibaseRDF\Application\MappingList;
+use ProfessionalWiki\WikibaseRDF\Application\MappingRepository;
+use Wikibase\DataModel\Entity\EntityId;
+
+class PermissionDeniedMappingRepository implements MappingRepository {
+
+	public function getMappings( EntityId $entityId ): MappingList {
+		throw new PermissionsError( 'edit' );
+	}
+
+	public function setMappings( EntityId $entityId, MappingList $mappingList ): void {
+		throw new PermissionsError( 'edit' );
+	}
+
+}

--- a/tests/TestDoubles/SpySaveMappingsPresenter.php
+++ b/tests/TestDoubles/SpySaveMappingsPresenter.php
@@ -4,8 +4,8 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\Tests\TestDoubles;
 
-use ProfessionalWiki\WikibaseRDF\Application\MappingList;
 use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsPresenter;
+use Throwable;
 
 class SpySaveMappingsPresenter implements SaveMappingsPresenter {
 
@@ -14,6 +14,7 @@ class SpySaveMappingsPresenter implements SaveMappingsPresenter {
 	public array $invalidMappings = [];
 	public bool $showedSaveFailed = false;
 	public bool $showedInvalidEntityId = false;
+	public Throwable $permissionDeniedException;
 
 	public function presentSuccess(): void {
 		$this->showedSuccess = true;
@@ -32,6 +33,10 @@ class SpySaveMappingsPresenter implements SaveMappingsPresenter {
 
 	public function presentInvalidEntityId(): void {
 		$this->showedInvalidEntityId = true;
+	}
+
+	public function presentPermissionDenied( Throwable $exception ): void {
+		$this->permissionDeniedException = $exception;
 	}
 
 }


### PR DESCRIPTION
Refs #45 

First stab at this. Not sure if this permission check is better off in the repo (like the PR) or in the UC. I imagine if the repo was used elsewhere we'd have to repeat the permission check. Thoughts?

I'm still trying to figure out how to use the MW API to get tokens and login via Curl. That's why I haven't updated the Readme yet.

----

## With anon edits blocked
LocalSettings:
```php
$wgGroupPermissions['*']['edit'] = false;
```
When you run:
```shell
curl -X POST -H 'Content-Type: application/json' "http://localhost:8484/rest.php/wikibase-rdf/v0/mappings/Q1" \
  -d '[{"predicate": "owl:sameAs", "object": "http://wwww.w3.org/2000/01/rdf-schema#subClassOf"}]' | jq
```
You get this:
![Screenshot_20220805_230552](https://user-images.githubusercontent.com/1428594/183179590-0129b179-40a8-414b-8a2d-b99619170ea8.png)

## With registered user edits blocked
LocalSettings:
```php
$wgGroupPermissions['*']['edit'] = false;
$wgGroupPermissions['user']['edit'] = false;
```
And then using the UI with a basic user:
![Screenshot_20220805_230655](https://user-images.githubusercontent.com/1428594/183181731-00b7fffd-cad0-40f5-b9e9-515e2221cbda.png)

