### PR TITLE
Config UI

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -34,6 +34,9 @@
 	},
 
 	"Hooks": {
+		"AlternateEdit": "ProfessionalWiki\\WikibaseRDF\\EntryPoints\\MediaWikiHooks::onAlternateEdit",
+		"ContentHandlerDefaultModelFor": "ProfessionalWiki\\WikibaseRDF\\EntryPoints\\MediaWikiHooks::onContentHandlerDefaultModelFor",
+		"EditFilter": "ProfessionalWiki\\WikibaseRDF\\EntryPoints\\MediaWikiHooks::onEditFilter",
 		"MediaWikiServices": "ProfessionalWiki\\WikibaseRDF\\EntryPoints\\MediaWikiHooks::onMediaWikiServices",
 		"OutputPageParserOutput": "ProfessionalWiki\\WikibaseRDF\\EntryPoints\\MediaWikiHooks::onOutputPageParserOutput",
 		"WikibaseRepoEntityTypes": "ProfessionalWiki\\WikibaseRDF\\EntryPoints\\MediaWikiHooks::onWikibaseRepoEntityTypes"

--- a/extension.json
+++ b/extension.json
@@ -64,6 +64,10 @@
 		}
 	},
 
+	"SpecialPages": {
+		"MappingPredicates": "ProfessionalWiki\\WikibaseRDF\\SpecialMappingPredicates"
+	},
+
 	"ResourceFileModulePaths": {
 		"localBasePath": "resources",
 		"remoteExtPath": "WikibaseRDF/resources"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,5 +18,7 @@
 
 	"wikibase-rdf-save-mappings-invalid-mappings": "Some of the mappings you specified are invalid",
 	"wikibase-rdf-save-mappings-save-failed": "Save failed",
-	"wikibase-rdf-entity-id-invalid": "The entity ID you specified is invalid"
+	"wikibase-rdf-entity-id-invalid": "The entity ID you specified is invalid",
+
+	"special-mapping-predicates": "Mapping predicates"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -20,5 +20,7 @@
 	"wikibase-rdf-save-mappings-save-failed": "Save failed",
 	"wikibase-rdf-entity-id-invalid": "The entity ID you specified is invalid",
 
+	"wikibase-rdf-config-invalid": "Invalid predicates:\n$1. Your changes were not saved.",
+
 	"special-mapping-predicates": "Mapping predicates"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -18,5 +18,6 @@
 	"wikibase-rdf-save-mappings-invalid-mappings": "This is an error message.",
 	"wikibase-rdf-save-mappings-save-failed": "This is an error message.",
 	"wikibase-rdf-entity-id-invalid": "This is an error message.",
+	"wikibase-rdf-config-invalid": "Error message shown when attempting to save invalid configuration on MediaWiki:MappingPredicates",
 	"special-mapping-predicates": "This is the label on \"Special:SpecialPages\" linking to \"MediaWiki:MappingPredicates\"."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -17,5 +17,6 @@
 	"wikibase-rdf-mappings-action-add": "This is the text on a button.",
 	"wikibase-rdf-save-mappings-invalid-mappings": "This is an error message.",
 	"wikibase-rdf-save-mappings-save-failed": "This is an error message.",
-	"wikibase-rdf-entity-id-invalid": "This is an error message."
+	"wikibase-rdf-entity-id-invalid": "This is an error message.",
+	"special-mapping-predicates": "This is the label on \"Special:SpecialPages\" linking to \"MediaWiki:MappingPredicates\"."
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9,8 +9,3 @@ parameters:
 			message: "#^Constant WB_NS_PROPERTY not found\\.$#"
 			count: 1
 			path: src/EntryPoints/MediaWikiHooks.php
-
-		-
-			message: "#^Method ProfessionalWiki\\\\WikibaseRDF\\\\WikibaseRdfExtension\\:\\:getAllowedPredicates\\(\\) should return array\\<string\\> but returns array\\.$#"
-			count: 1
-			path: src/WikibaseRdfExtension.php

--- a/src/Application/Predicate.php
+++ b/src/Application/Predicate.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Application;
+
+use InvalidArgumentException;
+
+class Predicate {
+
+	public function __construct(
+		public /* readonly */ string $predicate
+	) {
+		if ( !str_contains( $this->predicate, ':' ) ) {
+			throw new InvalidArgumentException( 'Invalid predicate' );
+		}
+	}
+
+}

--- a/src/Application/PredicateList.php
+++ b/src/Application/PredicateList.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Application;
+
+class PredicateList {
+
+	/**
+	 * @param Predicate[] $predicates
+	 */
+	public function __construct(
+		private array $predicates = []
+	) {
+	}
+
+	public function plus( self $predicates ): self {
+		return new self( array_merge( $this->predicates, $predicates->predicates ) );
+	}
+
+	public function contains(string $predicate ): bool {
+		return in_array( new Predicate( $predicate ), $this->predicates );
+	}
+
+	/**
+	 * @return Predicate[]
+	 */
+	public function asArray(): array {
+		return $this->predicates;
+	}
+
+}

--- a/src/Application/PredicateList.php
+++ b/src/Application/PredicateList.php
@@ -18,7 +18,7 @@ class PredicateList {
 		return new self( array_merge( $this->predicates, $predicates->predicates ) );
 	}
 
-	public function contains(string $predicate ): bool {
+	public function contains( string $predicate ): bool {
 		return in_array( new Predicate( $predicate ), $this->predicates );
 	}
 

--- a/src/Application/SaveMappings/SaveMappingsUseCase.php
+++ b/src/Application/SaveMappings/SaveMappingsUseCase.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\WikibaseRDF\Application\SaveMappings;
 
 use PermissionsError;
 use ProfessionalWiki\WikibaseRDF\Application\MappingRepository;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
 use ProfessionalWiki\WikibaseRDF\MappingListSerializer;
 use Throwable;
 use Wikibase\DataModel\Entity\EntityIdParser;
@@ -16,13 +17,10 @@ class SaveMappingsUseCase {
 	private const PREDICATE_KEY = 'predicate';
 	private const OBJECT_KEY = 'object';
 
-	/**
-	 * @param string[] $allowedPredicates
-	 */
 	public function __construct(
 		private SaveMappingsPresenter $presenter,
 		private MappingRepository $repository,
-		private array $allowedPredicates,
+		private PredicateList $allowedPredicates,
 		private EntityIdParser $entityIdParser,
 		private MappingListSerializer $mappingListSerializer
 	) {
@@ -110,7 +108,7 @@ class SaveMappingsUseCase {
 		return $predicate !== ''
 			&& $object !== ''
 			&& str_contains( $predicate, ':' )
-			&& in_array( $predicate, $this->allowedPredicates );
+			&& $this->allowedPredicates->contains( $predicate );
 	}
 
 }

--- a/src/DataAccess/CombiningMappingPredicatesLookup.php
+++ b/src/DataAccess/CombiningMappingPredicatesLookup.php
@@ -1,0 +1,44 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\DataAccess;
+
+use InvalidArgumentException;
+use ProfessionalWiki\WikibaseRDF\Application\Predicate;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
+
+class CombiningMappingPredicatesLookup implements MappingPredicatesLookup {
+
+	/**
+	 * @param array<array-key, mixed> $baseRules
+	 */
+	public function __construct(
+		private array $baseRules,
+		private WikiMappingPredicatesLookup $lookup
+	) {
+	}
+
+	public function getMappingPredicates(): PredicateList {
+		$predicates = $this->predicatesFromArray( $this->baseRules );
+		return $predicates->plus( $this->lookup->getMappingPredicates() );
+	}
+
+	/**
+	 * @param array<array-key, mixed> $predicates
+	 */
+	private function predicatesFromArray( array $predicates ): PredicateList {
+		$predicatesList = [];
+		foreach ( $predicates as $predicate ) {
+			if ( !is_string( $predicate ) ) {
+				continue;
+			}
+			try {
+				$predicatesList[] = new Predicate( $predicate );
+			} catch ( InvalidArgumentException ) {
+			}
+		}
+		return new PredicateList( $predicatesList );
+	}
+
+}

--- a/src/DataAccess/MappingPredicatesLookup.php
+++ b/src/DataAccess/MappingPredicatesLookup.php
@@ -1,0 +1,13 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\DataAccess;
+
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
+
+interface MappingPredicatesLookup {
+
+	public function getMappingPredicates(): PredicateList;
+
+}

--- a/src/DataAccess/PageContentFetcher.php
+++ b/src/DataAccess/PageContentFetcher.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\DataAccess;
+
+use MediaWiki\Revision\RevisionLookup;
+
+class PageContentFetcher {
+
+	private \TitleParser $titleParser;
+	private RevisionLookup $revisionLookup;
+
+	public function __construct( \TitleParser $titleParser, RevisionLookup $revisionLookup ) {
+		$this->titleParser = $titleParser;
+		$this->revisionLookup = $revisionLookup;
+	}
+
+	public function getPageContent( string $pageTitle ): ?\Content {
+		try {
+			$title = $this->titleParser->parseTitle( $pageTitle );
+		}
+		catch ( \MalformedTitleException $e ) {
+			return null;
+		}
+
+		$revision = $this->revisionLookup->getRevisionByTitle( $title );
+
+		return $revision?->getContent( 'main' );
+	}
+
+}

--- a/src/DataAccess/PredicatesDeserializer.php
+++ b/src/DataAccess/PredicatesDeserializer.php
@@ -9,7 +9,7 @@ use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
 
 class PredicatesDeserializer {
 
-	function __construct(
+	public function __construct(
 		private PredicatesTextValidator $validator
 	) {
 	}

--- a/src/DataAccess/PredicatesDeserializer.php
+++ b/src/DataAccess/PredicatesDeserializer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\DataAccess;
+
+use ProfessionalWiki\WikibaseRDF\Application\Predicate;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
+
+class PredicatesDeserializer {
+
+	function __construct(
+		private PredicatesTextValidator $validator
+	) {
+	}
+
+	public function deserialize( string $predicatesText ): PredicateList {
+		if ( !$this->validator->validate( $predicatesText ) ) {
+			return new PredicateList();
+		}
+
+		return new PredicateList(
+			array_values(
+				array_map(
+					fn( string $predicate ) => new Predicate( $predicate ),
+					$this->validator->getValidPredicates()
+				)
+			)
+		);
+	}
+
+}

--- a/src/DataAccess/PredicatesTextValidator.php
+++ b/src/DataAccess/PredicatesTextValidator.php
@@ -30,6 +30,9 @@ class PredicatesTextValidator {
 		return $this->invalidPredicates === [];
 	}
 
+	/**
+	 * @return string[]
+	 */
 	private function normalizeLines( string $predicatesText ): array {
 		return array_filter(
 			array_map(
@@ -43,10 +46,16 @@ class PredicatesTextValidator {
 		return str_contains( $predicate, ':' );
 	}
 
+	/**
+	 * @return string[]
+	 */
 	public function getValidPredicates(): array {
 		return $this->validPredicates;
 	}
 
+	/**
+	 * @return string[]
+	 */
 	public function getInvalidPredicates(): array {
 		return $this->invalidPredicates;
 	}

--- a/src/DataAccess/PredicatesTextValidator.php
+++ b/src/DataAccess/PredicatesTextValidator.php
@@ -1,0 +1,54 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\DataAccess;
+
+class PredicatesTextValidator {
+
+	/**
+	 * @var string[]
+	 */
+	private array $validPredicates = [];
+
+	/**
+	 * @var string[]
+	 */
+	private array $invalidPredicates = [];
+
+	public function validate( string $predicatesText ): bool {
+		$lines = $this->normalizeLines( $predicatesText );
+
+		foreach ( $lines as $line ) {
+			if ( $this->predicateIsValid( $line ) ) {
+				$this->validPredicates[] = $line;
+			} else {
+				$this->invalidPredicates[] = $line;
+			}
+		}
+
+		return $this->invalidPredicates === [];
+	}
+
+	private function normalizeLines( string $predicatesText ): array {
+		return array_filter(
+			array_map(
+				fn( string $predicate ) => trim( $predicate ),
+				explode( "\n", $predicatesText )
+			)
+		);
+	}
+
+	private function predicateIsValid( string $predicate ): bool {
+		return str_contains( $predicate, ':' );
+	}
+
+	public function getValidPredicates(): array {
+		return $this->validPredicates;
+	}
+
+	public function getInvalidPredicates(): array {
+		return $this->invalidPredicates;
+	}
+
+}

--- a/src/DataAccess/WikiMappingPredicatesLookup.php
+++ b/src/DataAccess/WikiMappingPredicatesLookup.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\DataAccess;
+
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
+
+class WikiMappingPredicatesLookup implements MappingPredicatesLookup {
+
+	public function __construct(
+		private PageContentFetcher $contentFetcher,
+		private PredicatesDeserializer $deserializer,
+		private string $pageName
+	) {
+	}
+
+	public function getMappingPredicates(): PredicateList {
+		$content = $this->contentFetcher->getPageContent( 'MediaWiki:' . $this->pageName );
+
+		if ( $content instanceof \TextContent ) {
+			return $this->predicatesFromTextContent( $content );
+		}
+
+		return new PredicateList();
+	}
+
+	private function predicatesFromTextContent( \TextContent $content ): PredicateList {
+		return $this->deserializer->deserialize( $content->getText() );
+	}
+
+}

--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -4,15 +4,18 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\EntryPoints;
 
+use EditPage;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\SlotRoleRegistry;
 use OutputPage;
 use ParserOutput;
+use ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesDeserializer;
+use ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesTextValidator;
 use ProfessionalWiki\WikibaseRDF\Presentation\RDF\MultiEntityRdfBuilder;
 use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
+use Title;
 use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\EntityIdParsingException;
-use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\Lib\EntityTypeDefinitions;
 use Wikibase\Repo\Rdf\EntityRdfBuilder;
 use Wikibase\Repo\Rdf\RdfVocabulary;
@@ -92,6 +95,36 @@ class MediaWikiHooks {
 			$factoryFunction( ...func_get_args() ),
 			WikibaseRdfExtension::getInstance()->newMappingRdfBuilder( $writer )
 		);
+	}
+
+	public static function onContentHandlerDefaultModelFor( Title $title, ?string &$model ): void {
+		if ( WikibaseRdfExtension::getInstance()->isConfigTitle( $title ) ) {
+			$model = CONTENT_MODEL_TEXT;
+		}
+	}
+
+	public static function onEditFilter( EditPage $editPage, ?string $text, ?string $section, string &$error ): void {
+		if ( is_string( $text ) && WikibaseRdfExtension::getInstance()->isConfigTitle( $editPage->getTitle() ) ) {
+			$validator = new PredicatesTextValidator();
+			if ( !$validator->validate( $text ) ) {
+				$invalidPredicates = join(
+					', ',
+					array_map(
+						fn( string $predicate) => '"' . $predicate . '"' ,
+						$validator->getInvalidPredicates()
+					)
+				);
+				$error = \Html::errorBox(
+					wfMessage( 'wikibase-rdf-config-invalid', $invalidPredicates )->escaped()
+				);
+			}
+		}
+	}
+
+	public static function onAlternateEdit( EditPage $editPage ): void {
+		if ( WikibaseRdfExtension::getInstance()->isConfigTitle( $editPage->getTitle() ) ) {
+			$editPage->suppressIntro = true;
+		}
 	}
 
 }

--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -107,10 +107,10 @@ class MediaWikiHooks {
 		if ( is_string( $text ) && WikibaseRdfExtension::getInstance()->isConfigTitle( $editPage->getTitle() ) ) {
 			$validator = new PredicatesTextValidator();
 			if ( !$validator->validate( $text ) ) {
-				$invalidPredicates = join(
+				$invalidPredicates = implode(
 					', ',
 					array_map(
-						fn( string $predicate) => '"' . $predicate . '"' ,
+						fn( string $predicate ) => '"' . $predicate . '"',
 						$validator->getInvalidPredicates()
 					)
 				);

--- a/src/Presentation/StubMappingsPresenter.php
+++ b/src/Presentation/StubMappingsPresenter.php
@@ -6,16 +6,14 @@ namespace ProfessionalWiki\WikibaseRDF\Presentation;
 
 use Html;
 use ProfessionalWiki\WikibaseRDF\Application\MappingList;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
 
 class StubMappingsPresenter implements MappingsPresenter {
 
 	private string $response = '';
 
-	/**
-	 * @param string[] $allowedPredicates
-	 */
 	public function __construct(
-		private array $allowedPredicates
+		private PredicateList $allowedPredicates
 	) {
 	}
 
@@ -77,8 +75,8 @@ class StubMappingsPresenter implements MappingsPresenter {
 
 	private function createPredicateSelect(): string {
 		$html = '<select name="wikibase-rdf-predicate">';
-		foreach ( $this->allowedPredicates as $predicate ) {
-			$html .= Html::element( 'option', [ 'value' => $predicate ], $predicate );
+		foreach ( $this->allowedPredicates->asArray() as $predicate ) {
+			$html .= Html::element( 'option', [ 'value' => $predicate->predicate ], $predicate->predicate );
 		}
 		$html .= '</select>';
 		return $html;

--- a/src/SpecialMappingPredicates.php
+++ b/src/SpecialMappingPredicates.php
@@ -1,0 +1,33 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF;
+
+use SpecialPage;
+
+class SpecialMappingPredicates extends SpecialPage {
+
+	public function __construct() {
+		parent::__construct( 'MappingPredicates' );
+	}
+
+	public function execute( $subPage ): void {
+		parent::execute( $subPage );
+
+		$title = \Title::newFromText( 'MediaWiki:MappingPredicates' );
+
+		if ( $title instanceof \Title ) {
+			$this->getOutput()->redirect( $title->getFullURL() );
+		}
+	}
+
+	public function getGroupName(): string {
+		return 'wikibase';
+	}
+
+	public function getDescription(): string {
+		return $this->msg( 'special-mapping-predicates' )->escaped();
+	}
+
+}

--- a/src/WikibaseRdfExtension.php
+++ b/src/WikibaseRdfExtension.php
@@ -9,6 +9,7 @@ use MediaWiki\Permissions\Authority;
 use MediaWiki\Rest\ResponseFactory;
 use ProfessionalWiki\WikibaseRDF\Application\AllMappingsLookup;
 use ProfessionalWiki\WikibaseRDF\Application\MappingRepository;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
 use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsPresenter;
 use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsUseCase;
 use ProfessionalWiki\WikibaseRDF\Application\ShowMappingsUseCase;
@@ -54,7 +55,7 @@ class WikibaseRdfExtension {
 
 	public function newStubMappingsPresenter(): StubMappingsPresenter {
 		return new StubMappingsPresenter(
-			$this->newMappingPredicatesLookup()->getMappingPredicates()
+			$this->getAllowedPredicates()
 		);
 	}
 
@@ -138,6 +139,10 @@ class WikibaseRdfExtension {
 		);
 	}
 
+	private function getAllowedPredicates(): PredicateList {
+		return $this->newMappingPredicatesLookup()->getMappingPredicates();
+	}
+
 	public function newSaveMappingsUseCase(
 		SaveMappingsPresenter $presenter,
 		Authority $authority
@@ -145,7 +150,7 @@ class WikibaseRdfExtension {
 		return new SaveMappingsUseCase(
 			$presenter,
 			$this->newMappingRepository( $authority ),
-			$this->newMappingPredicatesLookup()->getMappingPredicates(),
+			$this->getAllowedPredicates(),
 			$this->newEntityIdParser(),
 			$this->newMappingListSerializer()
 		);

--- a/tests/Application/PredicateListTest.php
+++ b/tests/Application/PredicateListTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseRDF\Application\Predicate;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseRDF\Application\PredicateList
+ */
+class PredicateListTest extends TestCase {
+
+	public function testCanConstructEmptyList(): void {
+		$list = new PredicateList();
+
+		$this->assertSame( [], $list->asArray() );
+	}
+
+	public function testCanAccessPredicatesAsArray(): void {
+		$predicatesArray = [
+			new Predicate( 'owl:sameAs' ),
+			new Predicate( 'rdfs:subClassOf' )
+		];
+
+		$list = new PredicateList( $predicatesArray );
+
+		$this->assertEquals( $predicatesArray, $list->asArray() );
+	}
+
+	public function testCanCombineLists(): void {
+		$predicatesArray1 = [
+			new Predicate( 'owl:sameAs' ),
+			new Predicate( 'rdfs:subClassOf' )
+		];
+
+		$list1 = new PredicateList( $predicatesArray1 );
+
+		$predicatesArray2 = [
+			new Predicate( 'foo:bar' ),
+			new Predicate( 'bar:baz' )
+		];
+
+		$list2 = new PredicateList( $predicatesArray2 );
+
+		$allList = new PredicateList( array_merge( $predicatesArray1, $predicatesArray2 ) );
+
+		$this->assertEquals( $allList, $list1->plus( $list2 ) );
+	}
+
+	public function testContainsPredicate(): void {
+		$list = new PredicateList( [
+			new Predicate( 'owl:sameAs' ),
+			new Predicate( 'rdfs:subClassOf' )
+		] );
+
+		$this->assertTrue( $list->contains( 'rdfs:subClassOf' ) );
+	}
+
+	public function testDoesNotContainPredicate(): void {
+		$list = new PredicateList( [
+			new Predicate( 'owl:sameAs' ),
+			new Predicate( 'rdfs:subClassOf' )
+		] );
+
+		$this->assertFalse( $list->contains( 'foo:bar' ) );
+	}
+
+}

--- a/tests/Application/PredicateTest.php
+++ b/tests/Application/PredicateTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\Application;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseRDF\Application\Predicate;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseRDF\Application\Predicate
+ */
+class PredicateTest extends TestCase {
+
+	public function testCanConstruct(): void {
+		$predicate = new Predicate( 'foo:bar' );
+		$this->assertEquals( 'foo:bar', $predicate->predicate );
+	}
+
+	public function testConstructorThrowsException(): void {
+		$this->expectException( InvalidArgumentException::class );
+		new Predicate( 'notvalid' );
+	}
+
+}

--- a/tests/Application/SaveMappings/SaveMappingsUseCaseTest.php
+++ b/tests/Application/SaveMappings/SaveMappingsUseCaseTest.php
@@ -6,6 +6,8 @@ namespace ProfessionalWiki\WikibaseRDF\Tests\Application\SaveMappings;
 
 use PermissionsError;
 use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseRDF\Application\Predicate;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
 use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsUseCase;
 use ProfessionalWiki\WikibaseRDF\MappingListSerializer;
 use ProfessionalWiki\WikibaseRDF\Persistence\InMemoryMappingRepository;
@@ -36,7 +38,7 @@ class SaveMappingsUseCaseTest extends TestCase {
 		return new SaveMappingsUseCase(
 			$this->presenter,
 			$this->repository,
-			[ self::VALID_PREDICATE ],
+			new PredicateList( [ new Predicate( self::VALID_PREDICATE ) ] ),
 			new BasicEntityIdParser(),
 			new MappingListSerializer()
 		);
@@ -106,7 +108,7 @@ class SaveMappingsUseCaseTest extends TestCase {
 		$useCase = new SaveMappingsUseCase(
 			$this->presenter,
 			new ThrowingMappingRepository(),
-			[ self::VALID_PREDICATE ],
+			new PredicateList( [ new Predicate( self::VALID_PREDICATE ) ] ),
 			new BasicEntityIdParser(),
 			new MappingListSerializer()
 		);
@@ -127,7 +129,7 @@ class SaveMappingsUseCaseTest extends TestCase {
 		$useCase = new SaveMappingsUseCase(
 			$this->presenter,
 			new ThrowingMappingRepository(),
-			[ self::VALID_PREDICATE ],
+			new PredicateList( [ new Predicate( self::VALID_PREDICATE ) ] ),
 			new BasicEntityIdParser(),
 			new MappingListSerializer()
 		);
@@ -146,7 +148,7 @@ class SaveMappingsUseCaseTest extends TestCase {
 		$useCase = new SaveMappingsUseCase(
 			$this->presenter,
 			new PermissionDeniedMappingRepository(),
-			[ self::VALID_PREDICATE ],
+			new PredicateList( [ new Predicate( self::VALID_PREDICATE ) ] ),
 			new BasicEntityIdParser(),
 			new MappingListSerializer()
 		);

--- a/tests/DataAccess/CombiningMappingPredicatesLookupTest.php
+++ b/tests/DataAccess/CombiningMappingPredicatesLookupTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\Application;
+
+use ProfessionalWiki\WikibaseRDF\Application\Predicate;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
+use ProfessionalWiki\WikibaseRDF\Tests\WikibaseRdfIntegrationTest;
+use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseRDF\DataAccess\CombiningMappingPredicatesLookup
+ */
+class CombiningMappingPredicatesLookupTest extends WikibaseRdfIntegrationTest {
+
+	public function testEmptyLocalSettingsAndEmptyPageConfig(): void {
+		$this->setAllowedPredicates( [] );
+		$this->createConfigPage( '' );
+
+		$lookup = WikibaseRdfExtension::getInstance()->newMappingPredicatesLookup();
+
+		$this->assertEquals(
+			new PredicateList(),
+			$lookup->getMappingPredicates()
+		);
+	}
+
+	public function testEmptyLocalSettingsAndValidPageConfigGetsCombined(): void {
+		$this->setAllowedPredicates( [] );
+		$this->createConfigPage( "foo:bar\nbar:Baz" );
+
+		$lookup = WikibaseRdfExtension::getInstance()->newMappingPredicatesLookup();
+
+		$this->assertEquals(
+			new PredicateList( [
+				new Predicate( 'foo:bar' ),
+				new Predicate( 'bar:Baz' )
+			] ),
+			$lookup->getMappingPredicates()
+		);
+	}
+
+	public function testValidLocalSettingsAndEmptyPageConfigGetsCombined(): void {
+		$this->setAllowedPredicates( [ 'owl:sameAs','owl:SymmetricProperty' ] );
+		$this->createConfigPage( '' );
+
+		$lookup = WikibaseRdfExtension::getInstance()->newMappingPredicatesLookup();
+
+		$this->assertEquals(
+			new PredicateList( [
+				new Predicate( 'owl:sameAs' ),
+				new Predicate( 'owl:SymmetricProperty' ),
+			] ),
+			$lookup->getMappingPredicates()
+		);
+	}
+
+	public function testInvalidLocalSettingsAreIgnored(): void {
+		$this->setAllowedPredicates( [ 'owl:sameAs','fooBar' ] );
+		$this->createConfigPage( '' );
+
+		$lookup = WikibaseRdfExtension::getInstance()->newMappingPredicatesLookup();
+
+		$this->assertEquals(
+			new PredicateList( [
+				new Predicate( 'owl:sameAs' ),
+			] ),
+			$lookup->getMappingPredicates()
+		);
+	}
+
+	public function testValidLocalSettingsAndValidPageConfigGetsCombined(): void {
+		$this->setAllowedPredicates( [ 'owl:sameAs','owl:SymmetricProperty' ] );
+		$this->createConfigPage( "foo:bar\nbar:Baz" );
+
+		$lookup = WikibaseRdfExtension::getInstance()->newMappingPredicatesLookup();
+
+		$this->assertEquals(
+			new PredicateList( [
+				new Predicate( 'owl:sameAs' ),
+				new Predicate( 'owl:SymmetricProperty' ),
+				new Predicate( 'foo:bar' ),
+				new Predicate( 'bar:Baz' ),
+			] ),
+			$lookup->getMappingPredicates()
+		);
+	}
+
+}

--- a/tests/DataAccess/PredicatesDeserializerTest.php
+++ b/tests/DataAccess/PredicatesDeserializerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseRDF\Application\Predicate;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
+use ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesDeserializer;
+use ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesTextValidator;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesDeserializer
+ */
+class PredicatesDeserializerTest extends TestCase {
+
+	private function newPredicateDeserializer(): PredicatesDeserializer {
+		return new PredicatesDeserializer(
+			new PredicatesTextValidator()
+		);
+	}
+
+	public function testValidPredicatesAreDeserialized(): void {
+		$predicates = $this->newPredicateDeserializer()->deserialize( "foo:bar\nbar:Baz" );
+
+		$this->assertEquals(
+			new PredicateList( [
+				new Predicate( 'foo:bar' ),
+				new Predicate( 'bar:Baz' ),
+			] ),
+			$predicates
+		);
+	}
+
+	public function testBlankLinesAreIgnored(): void {
+		$predicates = $this->newPredicateDeserializer()->deserialize( "\n\nfoo:bar\n\n\nbar:Baz\n\n" );
+
+		$this->assertEquals(
+			new PredicateList( [
+				new Predicate( 'foo:bar' ),
+				new Predicate( 'bar:Baz' ),
+			] ),
+			$predicates
+		);
+	}
+
+	public function testWhitespaceIsIgnored(): void {
+		$predicates = $this->newPredicateDeserializer()->deserialize( " foo:bar \n   \n bar:Baz  " );
+
+		$this->assertEquals(
+			new PredicateList( [
+				new Predicate( 'foo:bar' ),
+				new Predicate( 'bar:Baz' ),
+			] ),
+			$predicates
+		);
+	}
+
+	public function testInvalidPredicatesResultInEmptyList(): void {
+		$predicates = $this->newPredicateDeserializer()->deserialize( "notValid\nfoo:bar\nbar:Baz\nalsoNotValid" );
+
+		$this->assertEquals(
+			new PredicateList(),
+			$predicates
+		);
+	}
+
+}

--- a/tests/DataAccess/PredicatesTextValidatorTest.php
+++ b/tests/DataAccess/PredicatesTextValidatorTest.php
@@ -7,6 +7,9 @@ namespace ProfessionalWiki\WikibaseRDF\Tests\Application;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesTextValidator;
 
+/**
+ * @covers \ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesTextValidator
+ */
 class PredicatesTextValidatorTest extends TestCase {
 
 	public function testValidPredicatesAreValid(): void {

--- a/tests/DataAccess/PredicatesTextValidatorTest.php
+++ b/tests/DataAccess/PredicatesTextValidatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\Application;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesTextValidator;
+
+class PredicatesTextValidatorTest extends TestCase {
+
+	public function testValidPredicatesAreValid(): void {
+		$validator = new PredicatesTextValidator();
+
+		$this->assertTrue( $validator->validate( "foo:bar\nbar:Baz" ) );
+
+		$this->assertSame(
+			[ 'foo:bar', 'bar:Baz' ],
+			$validator->getValidPredicates()
+		);
+	}
+
+	public function testBlankLinesAreIgnored(): void {
+		$validator = new PredicatesTextValidator();
+
+		$this->assertTrue( $validator->validate( "\n\nfoo:bar\n\n\nbar:Baz\n\n" ) );
+
+		$this->assertSame(
+			[ 'foo:bar', 'bar:Baz' ],
+			$validator->getValidPredicates()
+		);
+	}
+
+	public function testWhitespaceIsIgnored(): void {
+		$validator = new PredicatesTextValidator();
+
+		$this->assertTrue( $validator->validate( " foo:bar \n   \n bar:Baz  " ) );
+
+		$this->assertSame(
+			[ 'foo:bar', 'bar:Baz' ],
+			$validator->getValidPredicates()
+		);
+	}
+
+	public function testInvalidPredicatesResultInEmptyList(): void {
+		$validator = new PredicatesTextValidator();
+
+		$this->assertFalse( $validator->validate( "notValid\nfoo:bar\nbar:Baz\nalsoNotValid" ) );
+
+		$this->assertSame(
+			[ 'notValid', 'alsoNotValid' ],
+			$validator->getInvalidPredicates()
+		);
+	}
+
+}

--- a/tests/DataAccess/WikiMappingPredicatesLookupTest.php
+++ b/tests/DataAccess/WikiMappingPredicatesLookupTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\Application;
+
+use MediaWiki\MediaWikiServices;
+use ProfessionalWiki\WikibaseRDF\Application\Predicate;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
+use ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesDeserializer;
+use ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesTextValidator;
+use ProfessionalWiki\WikibaseRDF\DataAccess\WikiMappingPredicatesLookup;
+use ProfessionalWiki\WikibaseRDF\DataAccess\PageContentFetcher;
+use ProfessionalWiki\WikibaseRDF\Tests\WikibaseRdfIntegrationTest;
+use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseRDF\DataAccess\WikiMappingPredicatesLookup
+ */
+class WikiMappingPredicatesLookupTest extends WikibaseRdfIntegrationTest {
+
+	private function newWikiMappingPredicatesLookup(): WikiMappingPredicatesLookup {
+		return new WikiMappingPredicatesLookup(
+			new PageContentFetcher(
+				MediaWikiServices::getInstance()->getTitleParser(),
+				MediaWikiServices::getInstance()->getRevisionLookup()
+			),
+			new PredicatesDeserializer(
+				new PredicatesTextValidator()
+			),
+			WikibaseRdfExtension::CONFIG_PAGE_TITLE
+		);
+	}
+
+	public function testEmptyConfigResultsInEmptyList(): void {
+		$this->createConfigPage( '' );
+
+		$lookup = $this->newWikiMappingPredicatesLookup();
+
+		$this->assertEquals(
+			new PredicateList(),
+			$lookup->getMappingPredicates()
+		);
+	}
+
+	public function testValidConfigIsRetrieved(): void {
+		$this->createConfigPage( "foo:bar\nbar:Baz" );
+
+		$lookup = $this->newWikiMappingPredicatesLookup();
+
+		$this->assertEquals(
+			new PredicateList( [
+				new Predicate( 'foo:bar' ),
+				new Predicate( 'bar:Baz' )
+			] ),
+			$lookup->getMappingPredicates()
+		);
+	}
+
+}

--- a/tests/Presentation/StubMappingsPresenterTest.php
+++ b/tests/Presentation/StubMappingsPresenterTest.php
@@ -7,6 +7,8 @@ namespace ProfessionalWiki\WikibaseRDF\Tests\Presentation;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\WikibaseRDF\Application\Mapping;
 use ProfessionalWiki\WikibaseRDF\Application\MappingList;
+use ProfessionalWiki\WikibaseRDF\Application\Predicate;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
 use ProfessionalWiki\WikibaseRDF\Presentation\StubMappingsPresenter;
 
 /**
@@ -14,14 +16,11 @@ use ProfessionalWiki\WikibaseRDF\Presentation\StubMappingsPresenter;
  */
 class StubMappingsPresenterTest extends TestCase {
 
-	/**
-	 * @return string[]
-	 */
-	private function getAllowedPredicates(): array {
-		return [
-			'owl:sameAs',
-			'skos:exactMatch',
-		];
+	private function getAllowedPredicates(): PredicateList {
+		return new PredicateList( [
+			new Predicate( 'owl:sameAs' ),
+			new Predicate( 'skos:exactMatch' ),
+		] );
 	}
 
 	public function testMappingValuesAreDisplayed(): void {

--- a/tests/WikibaseRdfIntegrationTest.php
+++ b/tests/WikibaseRdfIntegrationTest.php
@@ -85,4 +85,18 @@ class WikibaseRdfIntegrationTest extends MediaWikiIntegrationTestCase {
 		$this->setMwGlobals( 'wgWikibaseRdfPredicates', $predicates );
 	}
 
+	protected function createConfigPage( string $config ) {
+		$this->insertPage(
+			'MediaWiki:' . WikibaseRdfExtension::CONFIG_PAGE_TITLE,
+			$config
+		);
+	}
+
+	protected function editConfigPage( string $config ) {
+		$this->editPage(
+			'MediaWiki:' . WikibaseRdfExtension::CONFIG_PAGE_TITLE,
+			$config
+		);
+	}
+
 }

--- a/tests/WikibaseRdfIntegrationTest.php
+++ b/tests/WikibaseRdfIntegrationTest.php
@@ -85,14 +85,14 @@ class WikibaseRdfIntegrationTest extends MediaWikiIntegrationTestCase {
 		$this->setMwGlobals( 'wgWikibaseRdfPredicates', $predicates );
 	}
 
-	protected function createConfigPage( string $config ) {
+	protected function createConfigPage( string $config ): void {
 		$this->insertPage(
 			'MediaWiki:' . WikibaseRdfExtension::CONFIG_PAGE_TITLE,
 			$config
 		);
 	}
 
-	protected function editConfigPage( string $config ) {
+	protected function editConfigPage( string $config ): void {
 		$this->editPage(
 			'MediaWiki:' . WikibaseRdfExtension::CONFIG_PAGE_TITLE,
 			$config


### PR DESCRIPTION
Refs #71 

Does not include caching. Let's add that separately, since this is getting big.

I used the Text content model to avoid any Wikitext parsing. Not sure if there's a use case where we specifically want to use wikitext features while defining the list. The current implementation will ignore and strip blank lines and whitespace on valid lines.

Adding valid predicates:
![Screenshot_20220808_232212](https://user-images.githubusercontent.com/1428594/183516960-9b564ae1-769e-42e7-a06a-a40a8fa55cc6.png)
![Screenshot_20220808_232238](https://user-images.githubusercontent.com/1428594/183517016-68e08082-dad7-4e1d-87bb-adffad17d181.png)

Adding invalid predicates:
![Screenshot_20220808_232312](https://user-images.githubusercontent.com/1428594/183517101-529993fa-c2b5-49dc-947d-46dfb8072746.png)

Mapping UI with predicates added via config UI:
![Screenshot_20220808_232515](https://user-images.githubusercontent.com/1428594/183517426-1c5d45c2-cbe4-43f0-b4b7-645737520449.png)

