### PR TITLE
Refactor save mappings API test

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Alternatively, you can execute commands from the MediaWiki root directory:
 Save all RDF mappings for an existing entity (e.g. Q1):
 
 ```shell
-curl -X PUT -H 'Content-Type: application/json' "http://localhost:8484/rest.php/wikibase-rdf/v0/mappings/Q1" \
+curl -X POST -H 'Content-Type: application/json' "http://localhost:8484/rest.php/wikibase-rdf/v0/mappings/Q1" \
   -d '[{"predicate": "owl:sameAs", "object": "http://www.w3.org/2000/01/rdf-schema#subClassOf"}, {"predicate": "owl:sameAs", "object": "owl:subClassOf"}, {"predicate": "foo:bar", "object": "http://example.com"}]'
 ```
 


### PR DESCRIPTION
Very quick follow up to https://github.com/ProfessionalWiki/WikibaseRDF/pull/64#pullrequestreview-1064093533

I took a slightly different approach by moving all of the request logic into a method.
Does this make it cleaner, or do you think it is more useful to have an explicit concept of a "valid request"?