### PR TITLE
Show localized error message

### DIFF
--- a/resources/ext.wikibase.rdf.js
+++ b/resources/ext.wikibase.rdf.js
@@ -52,8 +52,7 @@ $( function () {
 
 	function showError( error ) {
 		console.log( 'showError' );
-		// TODO: i18n message
-		$( '.wikibase-rdf-error' ).text( JSON.stringify( error ) ).show();
+		$( '.wikibase-rdf-error' ).text( error ).show();
 	}
 
 	function onSuccessfulSave( trigger ) {
@@ -137,7 +136,20 @@ $( function () {
 				enableActions();
 			} )
 			.fail( function ( data, response ) {
-				showError( response.xhr.responseJSON );
+				const userLang = mw.config.get( 'wgUserLanguage' );
+				const siteLang = mw.config.get( 'wgContentLanguage' );
+				if ( response.xhr.responseJSON.hasOwnProperty( 'messageTranslations' ) ) {
+					if ( userLang in response.xhr.responseJSON.messageTranslations ) {
+						showError( response.xhr.responseJSON.messageTranslations[userLang] );
+					} else if ( siteLang in response.xhr.responseJSON.messageTranslations ) {
+						showError( response.xhr.responseJSON.messageTranslations[siteLang] );
+					} else {
+						showError( response.xhr.responseJSON.messageTranslations['en'] );
+					}
+				} else {
+					// TOOD: Handle other message structures
+					showError( JSON.stringify( response.xhr.responseJSON ) );
+				}
 				enableActions();
 			} );
 	}


### PR DESCRIPTION
Refs #66 

After #65 we should theoretically only be getting our own error responses using `ResponseFactory::createLocalizedHttpError()`. The previous anonymous error message (from MW, not us) shouldn't happen because the UI won't show the edit actions when not allowed. This PR therefore handles the known response structure based on that response method.

---

I am not sure that the error message localization approach is correct, though.

With English defaults (and forced exception in the code):
![Screenshot_20220809_171743](https://user-images.githubusercontent.com/1428594/183689015-92aaf052-da13-47c7-b204-d31d27d63e69.png)
Response:
![Screenshot_20220809_173204](https://user-images.githubusercontent.com/1428594/183693630-2af27d81-5b27-408f-8216-e95ab9d4f376.png)

With LocalSettings `$wgLanguageCode = 'de';`:
![Screenshot_20220809_171840](https://user-images.githubusercontent.com/1428594/183689237-68789d9b-d841-4798-8737-016d378176c3.png)
Response:
![Screenshot_20220809_173133](https://user-images.githubusercontent.com/1428594/183693396-9a713442-beae-4be2-be91-b2941f0b73b2.png)

With LocalSettings `$wgLanguageCode = 'de';` and user language = French:
![Screenshot_20220809_172641](https://user-images.githubusercontent.com/1428594/183691226-c0a058a4-2809-455b-8c35-85a57914db80.png)
Response:
![Screenshot_20220809_173104](https://user-images.githubusercontent.com/1428594/183693220-df040e9d-da1e-4393-a4a6-e5007f132755.png)

This seems to be because `createLocalizedHttpError()` returns only 'en' and the the value of `$wgLanguageCode`:
`EntryPoint::getTextFormatters()`:
![Screenshot_20220809_172944](https://user-images.githubusercontent.com/1428594/183692606-e8996370-10e3-4420-b314-b73ea15acb98.png)
`

I suspect we might need to add the message key to the response as well and then get the correct translation in JavaScript using `mw.msg(...)`.