### PR TITLE
Better UI

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -67,7 +67,7 @@
 
 		<UndefinedFunction>
 			<errorLevel type="suppress">
-				<file name="src/Presentation/StubMappingsPresenter.php" />
+				<file name="src/Presentation/HtmlMappingsPresenter.php" />
 			</errorLevel>
 		</UndefinedFunction>
 	</issueHandlers>

--- a/resources/ext.wikibase.rdf.js
+++ b/resources/ext.wikibase.rdf.js
@@ -30,6 +30,7 @@ $( function () {
 		const $row = $( '.wikibase-rdf-row-editing-template' ).clone();
 		$row.find( '.wikibase-rdf-action-remove' ).remove();
 		$row.removeClass( 'wikibase-rdf-row-editing-template' );
+		$row.addClass( 'wikibase-rdf-row' );
 		$row.addClass( 'wikibase-rdf-row-editing-add' );
 		$row.appendTo( $( '.wikibase-rdf-rows' ) );
 	}

--- a/resources/ext.wikibase.rdf.js
+++ b/resources/ext.wikibase.rdf.js
@@ -174,6 +174,7 @@ $( function () {
 
 		if ( $row.hasClass( 'wikibase-rdf-row-editing-add' ) ) {
 			$row.remove();
+			hideError();
 			return;
 		}
 
@@ -181,6 +182,7 @@ $( function () {
 		$row.removeClass( 'wikibase-rdf-row-editing' );
 		$row.find( '.wikibase-rdf-predicate' ).text( $row.data( 'predicate' ) );
 		$row.find( '.wikibase-rdf-object' ).text( $row.data( 'object' ) );
+		hideError();
 	}
 
 	function setupEvents() {

--- a/resources/ext.wikibase.rdf.less
+++ b/resources/ext.wikibase.rdf.less
@@ -5,33 +5,40 @@
 	width: 100%;
 }
 
-#wikibase-rdf-mappings {
-	margin: 0 2em 2em 0;
-	max-width: 65em;
-	width: 100%;
-
+#wikibase-rdf-mappings table {
 	background: #fff;
 	border: 1px solid #c8ccd1;
+	border-spacing: 0;
+	display: table;
+	table-layout: fixed;
+	width: 100%;
+	word-wrap: break-word;
 }
 
-#wikibase-rdf-header {
-	display: flex;
-	width: 100%;
+#wikibase-rdf-header th {
+	background-color: #eaecf0;
+	border-right: 1px solid #fff;
+	padding: 0 0 0 0.4em;
+	position: sticky;
+	top: 0;
+	font-weight: inherit;
+	text-align: left;
 }
 
 .wikibase-rdf-mappings-predicate-heading {
-	background-color: #eaecf0;
 	width: 15em;
 }
 
-.wikibase-rdf-mappings-object-heading {
-	background-color: #eaecf0;
-	flex-grow: 1;
+.wikibase-rdf-mappings-actions-heading {
+	width: 18em;
 }
 
-.wikibase-rdf-mappings-actions-heading {
-	background-color: #eaecf0;
-	width: 18em;
+.wikibase-rdf-rows td {
+	line-height: 136%;
+	overflow: hidden;
+	padding: 0.4em;
+	text-overflow: ellipsis;
+	vertical-align: top;
 }
 
 .wikibase-rdf-error {
@@ -44,11 +51,6 @@
 	color: unset;
 }
 
-.wikibase-rdf-row {
-	display: flex;
-	width: 100%;
-}
-
 .wikibase-rdf-row-editing-template {
 	display: none;
 }
@@ -57,24 +59,16 @@
 	display: none;
 }
 
-.wikibase-rdf-predicate {
-	width: 15em;
-}
-
 .wikibase-rdf-predicate select {
-	width: 95%;
-}
-
-.wikibase-rdf-object {
-	flex-grow: 1;
+	width: 100%;
 }
 
 .wikibase-rdf-object input {
-	width: 95%;
+	width: 100%;
 }
 
-.wikibase-rdf-actions {
-	width: 18em;
+.wikibase-rdf-actions a {
+	font-size: small;
 }
 
 #wikibase-rdf .icon {
@@ -120,5 +114,15 @@
 }
 
 .wikibase-rdf-footer {
-	background-color: #eaecf0;
+	overflow: hidden;
+}
+
+.wikibase-rdf-footer-actions {
+	float: right;
+	padding: 0.4em;
+	width: 18em;
+}
+
+.wikibase-rdf-action-add {
+	font-size: small;
 }

--- a/resources/ext.wikibase.rdf.less
+++ b/resources/ext.wikibase.rdf.less
@@ -42,7 +42,6 @@
 }
 
 .wikibase-rdf-error {
-	border: 1px solid @color-destructive;
 	color: @color-destructive;
 }
 

--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -67,7 +67,7 @@ class MediaWikiHooks {
 		// TODO: load styles earlier because this causes the initial content to be unstyled
 		$page->addModules( 'ext.wikibase.rdf' );
 
-		$presenter = WikibaseRdfExtension::getInstance()->newStubMappingsPresenter();
+		$presenter = WikibaseRdfExtension::getInstance()->newHtmlMappingsPresenter();
 
 		$useCase = WikibaseRdfExtension::getInstance()->newShowMappingsUseCase( $presenter, $page->getUser() );
 		$useCase->showMappings( $entityId );

--- a/src/Presentation/HtmlMappingsPresenter.php
+++ b/src/Presentation/HtmlMappingsPresenter.php
@@ -8,7 +8,7 @@ use Html;
 use ProfessionalWiki\WikibaseRDF\Application\MappingList;
 use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
 
-class StubMappingsPresenter implements MappingsPresenter {
+class HtmlMappingsPresenter implements MappingsPresenter {
 
 	private string $response = '';
 

--- a/src/Presentation/HtmlMappingsPresenter.php
+++ b/src/Presentation/HtmlMappingsPresenter.php
@@ -21,57 +21,60 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 		$this->response = '<div id="wikibase-rdf" style="display: none;">'
 			. '<div id="wikibase-rdf-toggler"></div>'
 			. '<div class id="wikibase-rdf-mappings">'
+			. '<table>'
+			. $this->createHeader()
+			. '<tbody class="wikibase-rdf-rows">'
 			. $this->createEditTemplate( $canEdit )
 			. $this->createRowTemplate( $canEdit )
-			. $this->createHeader()
 			. $this->createErrorBox()
 			. $this->createRows( $mappingList, $canEdit )
+			. '</tbody>'
+			. '</table>'
 			. $this->createFooter( $canEdit )
 			. '</div>'
 			. '</div>';
 	}
 
 	private function createHeader(): string {
-		return '<div id="wikibase-rdf-header">'
-			. '<span class="wikibase-rdf-mappings-predicate-heading">' . wfMessage( 'wikibase-rdf-mappings-predicate-heading' ) . '</span>'
-			. '<span class="wikibase-rdf-mappings-object-heading">' . wfMessage( 'wikibase-rdf-mappings-object-heading' ) . '</span>'
-			. '<span class="wikibase-rdf-mappings-actions-heading"></span>'
-			. '</div>';
+		return '<thead id="wikibase-rdf-header"><tr>'
+			. '<th class="wikibase-rdf-mappings-predicate-heading">' . wfMessage( 'wikibase-rdf-mappings-predicate-heading' ) . '</th>'
+			. '<th class="wikibase-rdf-mappings-object-heading">' . wfMessage( 'wikibase-rdf-mappings-object-heading' ) . '</th>'
+			. '<th class="wikibase-rdf-mappings-actions-heading"></th>'
+			. '</tr></thead>';
 	}
 
 	private function createErrorBox(): string {
-		return '<div class="wikibase-rdf-error" style="display: none;"></div>';
+		return '<tr><td class="wikibase-rdf-error" style="display: none;" colspan="3"></td></tr>';
 	}
 
 	private function createEditTemplate( bool $canEdit ): string {
 		if ( !$canEdit ) {
 			return '';
 		}
-		return '<div class="wikibase-rdf-row wikibase-rdf-row-editing-template">'
-			. '<div class="wikibase-rdf-predicate">' . $this->createPredicateSelect() . '</div>'
-			. '<div class="wikibase-rdf-object"><input name="wikibase-rdf-object" value="" /></div>'
-			. '<div class="wikibase-rdf-actions">'
+		return '<tr class="wikibase-rdf-row-editing-template">'
+			. '<td class="wikibase-rdf-predicate">' . $this->createPredicateSelect() . '</td>'
+			. '<td class="wikibase-rdf-object"><input name="wikibase-rdf-object" value="" /></td>'
+			. '<td class="wikibase-rdf-actions">'
 			. '<a href="#" class="wikibase-rdf-action-save"><span class="icon"></span>' . wfMessage( 'wikibase-rdf-mappings-action-save' ) . '</a> '
 			. '<a href="#" class="wikibase-rdf-action-remove"><span class="icon"></span>' . wfMessage( 'wikibase-rdf-mappings-action-remove' ) . '</a> '
 			. '<a href="#" class="wikibase-rdf-action-cancel"><span class="icon"></span>' . wfMessage( 'wikibase-rdf-mappings-action-cancel' ) . '</a>'
-			. '</div>'
-			. '</div>';
+			. '</td>'
+			. '</tr>';
 	}
 
 	private function createRowTemplate( bool $canEdit ): string {
-		return '<div class="wikibase-rdf-row-template">'
-			. '<div class="wikibase-rdf-predicate"></div>'
-			. '<div class="wikibase-rdf-object"></div>'
-			. '<div class="wikibase-rdf-actions">' . $this->createEditButton( $canEdit ) . '</div>'
-			. '</div>';
+		return '<tr class="wikibase-rdf-row-template">'
+			. '<td class="wikibase-rdf-predicate"></td>'
+			. '<td class="wikibase-rdf-object"></td>'
+			. '<td class="wikibase-rdf-actions">' . $this->createEditButton( $canEdit ) . '</td>'
+			. '</tr>';
 	}
 
 	private function createRows( MappingList $mappingList, bool $canEdit ): string {
-		$html = '<div class="wikibase-rdf-rows">';
+		$html = '';
 		foreach ( $mappingList->asArray() as $mapping ) {
 			$html .= $this->createRow( $mapping->predicate, $mapping->object, $canEdit );
 		}
-		$html .= '</div>';
 
 		return $html;
 	}
@@ -87,11 +90,11 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 
 	private function createRow( string $relationship, string $url, bool $canEdit ): string {
 		return Html::rawElement(
-			'div',
+			'tr',
 			[ 'class' => 'wikibase-rdf-row', 'data-predicate' => $relationship, 'data-object' => $url ],
-			Html::element( 'div', [ 'class' => 'wikibase-rdf-predicate' ], $relationship )
-				. Html::element( 'div', [ 'class' => 'wikibase-rdf-object' ], $url )
-				. Html::rawElement( 'div', [ 'class' => 'wikibase-rdf-actions' ], $this->createEditButton( $canEdit ) )
+			Html::element( 'td', [ 'class' => 'wikibase-rdf-predicate' ], $relationship )
+				. Html::element( 'td', [ 'class' => 'wikibase-rdf-object' ], $url )
+				. Html::rawElement( 'td', [ 'class' => 'wikibase-rdf-actions' ], $this->createEditButton( $canEdit ) )
 		);
 	}
 
@@ -106,7 +109,9 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 		if ( !$canEdit ) {
 			return '';
 		}
-		return '<div class="wikibase-rdf-footer"><a href="#" class="wikibase-rdf-action-add"><span class="icon"></span>' . wfMessage( 'wikibase-rdf-mappings-action-add' ) . '</a></div>';
+		return '<div class="wikibase-rdf-footer"><div class="wikibase-rdf-footer-actions">'
+			. '<a href="#" class="wikibase-rdf-action-add"><span class="icon"></span>' . wfMessage( 'wikibase-rdf-mappings-action-add' ) . '</a>'
+			. '</div></div>';
 	}
 
 	public function getHtml(): string {

--- a/src/WikibaseRdfExtension.php
+++ b/src/WikibaseRdfExtension.php
@@ -30,7 +30,7 @@ use ProfessionalWiki\WikibaseRDF\Presentation\RDF\MappingRdfBuilder;
 use ProfessionalWiki\WikibaseRDF\EntryPoints\Rest\GetMappingsApi;
 use ProfessionalWiki\WikibaseRDF\EntryPoints\Rest\SaveMappingsApi;
 use ProfessionalWiki\WikibaseRDF\Presentation\RestSaveMappingsPresenter;
-use ProfessionalWiki\WikibaseRDF\Presentation\StubMappingsPresenter;
+use ProfessionalWiki\WikibaseRDF\Presentation\HtmlMappingsPresenter;
 use RequestContext;
 use Title;
 use User;
@@ -57,8 +57,8 @@ class WikibaseRdfExtension {
 		return $instance;
 	}
 
-	public function newStubMappingsPresenter(): StubMappingsPresenter {
-		return new StubMappingsPresenter(
+	public function newHtmlMappingsPresenter(): HtmlMappingsPresenter {
+		return new HtmlMappingsPresenter(
 			$this->getAllowedPredicates()
 		);
 	}

--- a/tests/Presentation/HtmlMappingsPresenterTest.php
+++ b/tests/Presentation/HtmlMappingsPresenterTest.php
@@ -9,12 +9,12 @@ use ProfessionalWiki\WikibaseRDF\Application\Mapping;
 use ProfessionalWiki\WikibaseRDF\Application\MappingList;
 use ProfessionalWiki\WikibaseRDF\Application\Predicate;
 use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
-use ProfessionalWiki\WikibaseRDF\Presentation\StubMappingsPresenter;
+use ProfessionalWiki\WikibaseRDF\Presentation\HtmlMappingsPresenter;
 
 /**
- * @covers \ProfessionalWiki\WikibaseRDF\Presentation\StubMappingsPresenter
+ * @covers \ProfessionalWiki\WikibaseRDF\Presentation\HtmlMappingsPresenter
  */
-class StubMappingsPresenterTest extends TestCase {
+class HtmlMappingsPresenterTest extends TestCase {
 
 	private const CLASS_ACTION_EDIT = 'wikibase-rdf-action-edit';
 	private const CLASS_ACTION_SAVE = 'wikibase-rdf-action-save';
@@ -30,7 +30,7 @@ class StubMappingsPresenterTest extends TestCase {
 	}
 
 	public function testMappingValuesAreDisplayed(): void {
-		$presenter = new StubMappingsPresenter( $this->getAllowedPredicates() );
+		$presenter = new HtmlMappingsPresenter( $this->getAllowedPredicates() );
 		$mapping1 = new Mapping( 'owl:sameAs', 'http://www.w3.org/2000/01/rdf-schema#subClassOf' );
 		$mapping2 = new Mapping( 'skos:exactMatch', 'http://www.example.com/foo' );
 
@@ -47,7 +47,7 @@ class StubMappingsPresenterTest extends TestCase {
 	}
 
 	public function testEditActionsAreDisplayed(): void {
-		$presenter = new StubMappingsPresenter( $this->getAllowedPredicates() );
+		$presenter = new HtmlMappingsPresenter( $this->getAllowedPredicates() );
 		$mapping1 = new Mapping( 'owl:sameAs', 'http://www.w3.org/2000/01/rdf-schema#subClassOf' );
 		$mapping2 = new Mapping( 'skos:exactMatch', 'http://www.example.com/foo' );
 
@@ -65,7 +65,7 @@ class StubMappingsPresenterTest extends TestCase {
 	}
 
 	public function testEditActionsAreNotDisplayed(): void {
-		$presenter = new StubMappingsPresenter( $this->getAllowedPredicates() );
+		$presenter = new HtmlMappingsPresenter( $this->getAllowedPredicates() );
 		$mapping1 = new Mapping( 'owl:sameAs', 'http://www.w3.org/2000/01/rdf-schema#subClassOf' );
 		$mapping2 = new Mapping( 'skos:exactMatch', 'http://www.example.com/foo' );
 


### PR DESCRIPTION
Refs #28 

Based on the "languages" and "statements" sections.

I used less space above the "add mappings" button. It feels like the statements action is a bit too far away.

View (with permissions):
![Screenshot_20220810_183619](https://user-images.githubusercontent.com/1428594/183964996-387b78ef-087d-4106-8559-0715f73c3821.png)

View (without permissions):
![Screenshot_20220810_183650](https://user-images.githubusercontent.com/1428594/183965114-4f605fa6-009c-4939-b171-627d757aa298.png)

Edit:
![Screenshot_20220810_183713](https://user-images.githubusercontent.com/1428594/183965214-13a31221-bb68-4752-8bc5-ad0d7b02e600.png)

Error message:
![Screenshot_20220810_183858](https://user-images.githubusercontent.com/1428594/183965547-65966be4-6325-45e3-9135-b9cb5a04a95b.png)

Thoughts on this so far?