### PR TITLE
Format the defined predicates

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -35,6 +35,7 @@
 
 	"Hooks": {
 		"AlternateEdit": "ProfessionalWiki\\WikibaseRDF\\EntryPoints\\MediaWikiHooks::onAlternateEdit",
+		"ArticleRevisionViewCustom": "ProfessionalWiki\\WikibaseRDF\\EntryPoints\\MediaWikiHooks::onArticleRevisionViewCustom",
 		"ContentHandlerDefaultModelFor": "ProfessionalWiki\\WikibaseRDF\\EntryPoints\\MediaWikiHooks::onContentHandlerDefaultModelFor",
 		"EditFilter": "ProfessionalWiki\\WikibaseRDF\\EntryPoints\\MediaWikiHooks::onEditFilter",
 		"MediaWikiServices": "ProfessionalWiki\\WikibaseRDF\\EntryPoints\\MediaWikiHooks::onMediaWikiServices",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -24,5 +24,9 @@
 	"wikibase-rdf-config-intro": "Removing predicates that are in use on your wiki breaks the editing UI and is not recommended",
 	"wikibase-rdf-config-invalid": "Invalid {{PLURAL:$1|predicate|predicates}}:\n$2. Your changes were not saved.",
 
+	"wikibase-rdf-config-list-intro": "This page defines which predicates can be used in mappings to other ontologies. This functionality is part of the <a href=\"https://www.mediawiki.org/wiki/Extension:WikibaseRDF\">Wikibase RDF extension</a>.",
+	"wikibase-rdf-config-list-heading": "Allowed {{PLURAL:$1|predicate|predicates}}:",
+	"wikibase-rdf-config-list-empty": "No predicates are defined.",
+
 	"special-mapping-predicates": "Mapping predicates"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -27,6 +27,7 @@
 	"wikibase-rdf-config-list-intro": "This page defines which predicates can be used in mappings to other ontologies. This functionality is part of the <a href=\"https://www.mediawiki.org/wiki/Extension:WikibaseRDF\">Wikibase RDF extension</a>.",
 	"wikibase-rdf-config-list-heading": "Allowed {{PLURAL:$1|predicate|predicates}}:",
 	"wikibase-rdf-config-list-empty": "No predicates are defined.",
+	"wikibase-rdf-config-list-footer": "Defined in LocalSettings.php, cannot be modified via this page.",
 
 	"special-mapping-predicates": "Mapping predicates"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -24,5 +24,6 @@
 	"wikibase-rdf-config-list-intro": "This is the text shown at the top of \"MediaWiki:MappingPredicates\" when viewing.",
 	"wikibase-rdf-config-list-heading": "This is the text shown before the list of predicates on \"MediaWiki:MappingPredicates\".",
 	"wikibase-rdf-config-list-empty": "This is the text shown on \"MediaWiki:MappingPredicates\" when no predicates are defined.",
+	"wikibase-rdf-config-list-footer": "This is the text shown at the bottom of \"MediaWiki:MappingPredicates\" when viewing.",
 	"special-mapping-predicates": "This is the label on \"Special:SpecialPages\" linking to \"MediaWiki:MappingPredicates\"."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -19,7 +19,10 @@
 	"wikibase-rdf-save-mappings-save-failed": "This is an error message.",
 	"wikibase-rdf-entity-id-invalid": "This is an error message.",
 	"wikibase-rdf-permission-denied": "This is an error message.",
-	"wikibase-rdf-config-intro": "This is the text shown at the top of the form on \"MediaWiki:MappingPredicates\".",
-	"wikibase-rdf-config-invalid": "Error message shown when attempting to save invalid configuration on MediaWiki:MappingPredicates",
+	"wikibase-rdf-config-intro": "This is the text shown at the top of the form on \"MediaWiki:MappingPredicates\" when editing.",
+	"wikibase-rdf-config-invalid": "Error message shown when attempting to save invalid configuration on \"MediaWiki:MappingPredicates\"",
+	"wikibase-rdf-config-list-intro": "This is the text shown at the top of \"MediaWiki:MappingPredicates\" when viewing.",
+	"wikibase-rdf-config-list-heading": "This is the text shown before the list of predicates on \"MediaWiki:MappingPredicates\".",
+	"wikibase-rdf-config-list-empty": "This is the text shown on \"MediaWiki:MappingPredicates\" when no predicates are defined.",
 	"special-mapping-predicates": "This is the label on \"Special:SpecialPages\" linking to \"MediaWiki:MappingPredicates\"."
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11,14 +11,18 @@
   <file src="src/Presentation/HtmlPredicatesPresenter.php">
     <MixedArgument occurrences="3">
       <code>wfMessage( 'wikibase-rdf-config-list-empty' )-&gt;text()</code>
-      <code>wfMessage( 'wikibase-rdf-config-list-heading', count( $predicates ) )-&gt;text()</code>
+      <code>wfMessage( 'wikibase-rdf-config-list-heading', $count )-&gt;text()</code>
       <code>wfMessage( 'wikibase-rdf-config-list-intro' )-&gt;text()</code>
     </MixedArgument>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall occurrences="4">
+      <code>text</code>
       <code>text</code>
       <code>text</code>
       <code>text</code>
     </MixedMethodCall>
+    <MixedOperand occurrences="1">
+      <code>wfMessage( 'wikibase-rdf-config-list-footer' )-&gt;text()</code>
+    </MixedOperand>
   </file>
   <file src="src/WikibaseRdfExtension.php">
     <MixedArgumentTypeCoercion occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8,13 +8,21 @@
       <code>$array</code>
     </MixedAssignment>
   </file>
+  <file src="src/Presentation/HtmlPredicatesPresenter.php">
+    <MixedArgument occurrences="3">
+      <code>wfMessage( 'wikibase-rdf-config-list-empty' )-&gt;text()</code>
+      <code>wfMessage( 'wikibase-rdf-config-list-heading', count( $predicates ) )-&gt;text()</code>
+      <code>wfMessage( 'wikibase-rdf-config-list-intro' )-&gt;text()</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="3">
+      <code>text</code>
+      <code>text</code>
+      <code>text</code>
+    </MixedMethodCall>
+  </file>
   <file src="src/WikibaseRdfExtension.php">
     <MixedArgumentTypeCoercion occurrences="1">
       <code>(array)$services-&gt;getMainConfig()-&gt;get( 'AvailableRights' )</code>
     </MixedArgumentTypeCoercion>
-    <MixedReturnTypeCoercion occurrences="2">
-      <code>(array)MediaWikiServices::getInstance()-&gt;getMainConfig()-&gt;get( 'WikibaseRdfPredicates' )</code>
-      <code>string[]</code>
-    </MixedReturnTypeCoercion>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -67,7 +67,8 @@
 
 		<UndefinedFunction>
 			<errorLevel type="suppress">
-				<file name="src/Presentation/HtmlMappingsPresenter.php" />
+				<referencedFunction name="wfMessage"/>
+				<directory name="src" />
 			</errorLevel>
 		</UndefinedFunction>
 	</issueHandlers>

--- a/src/DataAccess/CombiningMappingPredicatesLookup.php
+++ b/src/DataAccess/CombiningMappingPredicatesLookup.php
@@ -10,35 +10,14 @@ use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
 
 class CombiningMappingPredicatesLookup implements MappingPredicatesLookup {
 
-	/**
-	 * @param array<array-key, mixed> $baseRules
-	 */
 	public function __construct(
-		private array $baseRules,
-		private WikiMappingPredicatesLookup $lookup
+		private LocalSettingsMappingPredicatesLookup $localSettingLookup,
+		private WikiMappingPredicatesLookup $wikiLookup
 	) {
 	}
 
 	public function getMappingPredicates(): PredicateList {
-		$predicates = $this->predicatesFromArray( $this->baseRules );
-		return $predicates->plus( $this->lookup->getMappingPredicates() );
-	}
-
-	/**
-	 * @param array<array-key, mixed> $predicates
-	 */
-	private function predicatesFromArray( array $predicates ): PredicateList {
-		$predicatesList = [];
-		foreach ( $predicates as $predicate ) {
-			if ( !is_string( $predicate ) ) {
-				continue;
-			}
-			try {
-				$predicatesList[] = new Predicate( $predicate );
-			} catch ( InvalidArgumentException ) {
-			}
-		}
-		return new PredicateList( $predicatesList );
+		return $this->localSettingLookup->getMappingPredicates()->plus( $this->wikiLookup->getMappingPredicates() );
 	}
 
 }

--- a/src/DataAccess/LocalSettingsMappingPredicatesLookup.php
+++ b/src/DataAccess/LocalSettingsMappingPredicatesLookup.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\DataAccess;
+
+use InvalidArgumentException;
+use ProfessionalWiki\WikibaseRDF\Application\Predicate;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
+
+class LocalSettingsMappingPredicatesLookup implements MappingPredicatesLookup {
+
+	/**
+	 * @param array<array-key, mixed> $predicates
+	 */
+	public function __construct(
+		private array $predicates
+	) {
+	}
+
+	public function getMappingPredicates(): PredicateList {
+		$predicatesList = [];
+		foreach ( $this->predicates as $predicate ) {
+			if ( !is_string( $predicate ) ) {
+				continue;
+			}
+			try {
+				$predicatesList[] = new Predicate( $predicate );
+			} catch ( InvalidArgumentException ) {
+			}
+		}
+		return new PredicateList( $predicatesList );
+	}
+
+}

--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\WikibaseRDF\EntryPoints;
 
 use EditPage;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRoleRegistry;
 use OutputPage;
 use ParserOutput;
@@ -135,6 +136,23 @@ class MediaWikiHooks {
 			$editPage->suppressIntro = true;
 			$editPage->editFormTextBeforeContent = wfMessage( 'wikibase-rdf-config-intro' );
 		}
+	}
+
+	public static function onArticleRevisionViewCustom(
+		RevisionRecord $revision,
+		Title $title,
+		int $oldId,
+		OutputPage $output
+	): bool {
+		if ( WikibaseRdfExtension::getInstance()->isConfigTitle( $title ) ) {
+			$lookup = WikibaseRdfExtension::getInstance()->newMappingPredicatesLookup();
+			$presenter = WikibaseRdfExtension::getInstance()->newHtmlPredicatesPresenter();
+			$presenter->presentPredicates( $lookup->getMappingPredicates() );
+			$output->clearHTML();
+			$output->addHTML( $presenter->getHtml() );
+			return false;
+		}
+		return true;
 	}
 
 }

--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -145,9 +145,13 @@ class MediaWikiHooks {
 		OutputPage $output
 	): bool {
 		if ( WikibaseRdfExtension::getInstance()->isConfigTitle( $title ) ) {
-			$lookup = WikibaseRdfExtension::getInstance()->newMappingPredicatesLookup();
+			$localSettingsLookup = WikibaseRdfExtension::getInstance()->newLocalSettingsMappingPredicatesLookup();
+			$wikiSettingsLookup = WikibaseRdfExtension::getInstance()->newWikiMappingPredicatesLookup();
 			$presenter = WikibaseRdfExtension::getInstance()->newHtmlPredicatesPresenter();
-			$presenter->presentPredicates( $lookup->getMappingPredicates() );
+			$presenter->presentPredicates(
+				$localSettingsLookup->getMappingPredicates(),
+				$wikiSettingsLookup->getMappingPredicates()
+			);
 			$output->clearHTML();
 			$output->addHTML( $presenter->getHtml() );
 			return false;

--- a/src/Presentation/HtmlPredicatesPresenter.php
+++ b/src/Presentation/HtmlPredicatesPresenter.php
@@ -1,0 +1,50 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Presentation;
+
+use Html;
+use ProfessionalWiki\WikibaseRDF\Application\Predicate;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
+
+class HtmlPredicatesPresenter implements PredicatesPresenter {
+
+	private string $response = '';
+	private PredicateList $predicates;
+
+	public function presentPredicates( PredicateList $predicates ): void {
+		$this->predicates = $predicates;
+		$this->response = $this->createIntro() . $this->createList();
+	}
+
+	private function createIntro(): string {
+		return Html::rawElement( 'p', [], wfMessage( 'wikibase-rdf-config-list-intro' )->text() );
+	}
+
+	private function createList(): string {
+		$predicates = $this->predicates->asArray();
+
+		if ( count( $predicates ) === 0 ) {
+			return Html::element( 'p', [], wfMessage( 'wikibase-rdf-config-list-empty' )->text() );
+		}
+
+		return Html::element( 'p', [], wfMessage( 'wikibase-rdf-config-list-heading', count( $predicates ) )->text() )
+			. Html::rawElement( 'ul', [], implode( $this->createListItems() ) );
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function createListItems(): array {
+		return array_map(
+			fn( Predicate $predicate ) => Html::element( 'li', [], $predicate->predicate ),
+			$this->predicates->asArray()
+		);
+	}
+
+	public function getHtml(): string {
+		return $this->response;
+	}
+
+}

--- a/src/Presentation/PredicatesPresenter.php
+++ b/src/Presentation/PredicatesPresenter.php
@@ -8,6 +8,6 @@ use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
 
 interface PredicatesPresenter {
 
-	public function presentPredicates( PredicateList $predicates ): void;
+	public function presentPredicates( PredicateList $localSettingsPredicates, PredicateList $wikiPredicates ): void;
 
 }

--- a/src/Presentation/PredicatesPresenter.php
+++ b/src/Presentation/PredicatesPresenter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Presentation;
+
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
+
+interface PredicatesPresenter {
+
+	public function presentPredicates( PredicateList $predicates ): void;
+
+}

--- a/src/WikibaseRdfExtension.php
+++ b/src/WikibaseRdfExtension.php
@@ -15,6 +15,7 @@ use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsPresenter;
 use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsUseCase;
 use ProfessionalWiki\WikibaseRDF\Application\ShowMappingsUseCase;
 use ProfessionalWiki\WikibaseRDF\DataAccess\CombiningMappingPredicatesLookup;
+use ProfessionalWiki\WikibaseRDF\DataAccess\LocalSettingsMappingPredicatesLookup;
 use ProfessionalWiki\WikibaseRDF\DataAccess\MappingPredicatesLookup;
 use ProfessionalWiki\WikibaseRDF\DataAccess\PageContentFetcher;
 use ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesDeserializer;
@@ -170,19 +171,29 @@ class WikibaseRdfExtension {
 		);
 	}
 
-	public function newMappingPredicatesLookup(): MappingPredicatesLookup {
+	public function newLocalSettingsMappingPredicatesLookup(): LocalSettingsMappingPredicatesLookup {
+		return new LocalSettingsMappingPredicatesLookup(
+			(array)MediaWikiServices::getInstance()->getMainConfig()->get( 'WikibaseRdfPredicates' )
+		);
+	}
+
+	public function newWikiMappingPredicatesLookup(): WikiMappingPredicatesLookup {
+		return new WikiMappingPredicatesLookup(
+			new PageContentFetcher(
+				MediaWikiServices::getInstance()->getTitleParser(),
+				MediaWikiServices::getInstance()->getRevisionLookup()
+			),
+			new PredicatesDeserializer(
+				new PredicatesTextValidator()
+			),
+			self::CONFIG_PAGE_TITLE
+		);
+	}
+
+	public function newMappingPredicatesLookup(): CombiningMappingPredicatesLookup {
 		return new CombiningMappingPredicatesLookup(
-			(array)MediaWikiServices::getInstance()->getMainConfig()->get( 'WikibaseRdfPredicates' ),
-			new WikiMappingPredicatesLookup(
-				new PageContentFetcher(
-					MediaWikiServices::getInstance()->getTitleParser(),
-					MediaWikiServices::getInstance()->getRevisionLookup()
-				),
-				new PredicatesDeserializer(
-					new PredicatesTextValidator()
-				),
-				self::CONFIG_PAGE_TITLE
-			)
+			$this->newLocalSettingsMappingPredicatesLookup(),
+			$this->newWikiMappingPredicatesLookup()
 		);
 	}
 

--- a/src/WikibaseRdfExtension.php
+++ b/src/WikibaseRdfExtension.php
@@ -25,6 +25,7 @@ use ProfessionalWiki\WikibaseRDF\Persistence\ContentSlotMappingRepository;
 use ProfessionalWiki\WikibaseRDF\Persistence\SlotEntityContentRepository;
 use ProfessionalWiki\WikibaseRDF\Persistence\SqlAllMappingsLookup;
 use ProfessionalWiki\WikibaseRDF\Persistence\UserBasedEntityMappingsAuthorizer;
+use ProfessionalWiki\WikibaseRDF\Presentation\HtmlPredicatesPresenter;
 use ProfessionalWiki\WikibaseRDF\Presentation\MappingsPresenter;
 use ProfessionalWiki\WikibaseRDF\Presentation\RDF\MappingRdfBuilder;
 use ProfessionalWiki\WikibaseRDF\EntryPoints\Rest\GetMappingsApi;
@@ -204,6 +205,10 @@ class WikibaseRdfExtension {
 			$user,
 			$this->newEntityPermissionChecker( MediaWikiServices::getInstance() )
 		);
+	}
+
+	public function newHtmlPredicatesPresenter(): HtmlPredicatesPresenter {
+		return new HtmlPredicatesPresenter();
 	}
 
 }

--- a/tests/DataAccess/LocalSettingsMappingPredicatesLookupTest.php
+++ b/tests/DataAccess/LocalSettingsMappingPredicatesLookupTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\Application;
+
+use ProfessionalWiki\WikibaseRDF\Application\Predicate;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
+use ProfessionalWiki\WikibaseRDF\DataAccess\LocalSettingsMappingPredicatesLookup;
+use ProfessionalWiki\WikibaseRDF\Tests\WikibaseRdfIntegrationTest;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseRDF\DataAccess\LocalSettingsMappingPredicatesLookup
+ */
+class LocalSettingsMappingPredicatesLookupTest extends WikibaseRdfIntegrationTest {
+
+	public function testEmptyConfigReturnsEmptyList(): void {
+		$mappings = [];
+		$lookup = new LocalSettingsMappingPredicatesLookup( $mappings );
+
+		$this->assertEquals(
+			new PredicateList(),
+			$lookup->getMappingPredicates()
+		);
+	}
+
+	public function testValidPredicatesAreInList(): void {
+		$mappings = [ 'foo:bar', 'bar:baz' ];
+		$lookup = new LocalSettingsMappingPredicatesLookup( $mappings );
+
+		$this->assertEquals(
+			new PredicateList( [ new Predicate( 'foo:bar' ), new Predicate( 'bar:baz' ) ] ),
+			$lookup->getMappingPredicates()
+		);
+	}
+
+	public function testInvalidPredicatesAreNotInList(): void {
+		$mappings = [ 'foo:bar', 'not valid', 'bar:baz' ];
+		$lookup = new LocalSettingsMappingPredicatesLookup( $mappings );
+
+		$this->assertEquals(
+			new PredicateList( [ new Predicate( 'foo:bar' ), new Predicate( 'bar:baz' ) ] ),
+			$lookup->getMappingPredicates()
+		);
+	}
+
+}

--- a/tests/Presentation/HtmlPredicatesPresenterTest.php
+++ b/tests/Presentation/HtmlPredicatesPresenterTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\Presentation;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseRDF\Application\Predicate;
+use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
+use ProfessionalWiki\WikibaseRDF\Presentation\HtmlPredicatesPresenter;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseRDF\Presentation\HtmlPredicatesPresenter
+ */
+class HtmlPredicatesPresenterTest extends TestCase {
+
+	public function testHtmlContainsPredicates(): void {
+		$mappingList = new PredicateList( [ new Predicate( 'foo:bar' ), new Predicate( 'bar:baz' ) ] );
+		$presenter = new HtmlPredicatesPresenter();
+		$presenter->presentPredicates( $mappingList );
+
+		$html = $presenter->getHtml();
+
+		$this->assertStringContainsString( 'foo:bar', $html );
+		$this->assertStringContainsString( 'bar:baz', $html );
+	}
+
+	public function testHtmlContainsMessageIfNoPredicatesAreConfigured(): void {
+		$mappingList = new PredicateList();
+		$presenter = new HtmlPredicatesPresenter();
+		$presenter->presentPredicates( $mappingList );
+
+		$html = $presenter->getHtml();
+
+		$this->assertStringContainsString(
+			'No predicates are defined.',
+			$html
+		);
+	}
+
+}

--- a/tests/Presentation/HtmlPredicatesPresenterTest.php
+++ b/tests/Presentation/HtmlPredicatesPresenterTest.php
@@ -14,21 +14,53 @@ use ProfessionalWiki\WikibaseRDF\Presentation\HtmlPredicatesPresenter;
  */
 class HtmlPredicatesPresenterTest extends TestCase {
 
-	public function testHtmlContainsPredicates(): void {
-		$mappingList = new PredicateList( [ new Predicate( 'foo:bar' ), new Predicate( 'bar:baz' ) ] );
+	private const LOCAL_SETTINGS_MESSAGE = '<code>*</code> Defined in LocalSettings.php';
+
+	public function testHtmlContainsOnlyLocalSettingsPredicates(): void {
 		$presenter = new HtmlPredicatesPresenter();
-		$presenter->presentPredicates( $mappingList );
+		$presenter->presentPredicates(
+			new PredicateList( [ new Predicate( 'foo:bar' ), new Predicate( 'bar:baz' ) ] ),
+			new PredicateList()
+		);
 
 		$html = $presenter->getHtml();
 
-		$this->assertStringContainsString( 'foo:bar', $html );
-		$this->assertStringContainsString( 'bar:baz', $html );
+		$this->assertStringContainsString( '<li><span>foo:bar</span> <code>*</code></li>', $html );
+		$this->assertStringContainsString( '<li><span>bar:baz</span> <code>*</code></li>', $html );
+		$this->assertStringContainsString( self::LOCAL_SETTINGS_MESSAGE, $html );
+	}
+
+	public function testHtmlContainsOnlyWikiConfigPredicates(): void {
+		$presenter = new HtmlPredicatesPresenter();
+		$presenter->presentPredicates(
+			new PredicateList(),
+			new PredicateList( [ new Predicate( 'foo:bar' ), new Predicate( 'bar:baz' ) ] )
+		);
+
+		$html = $presenter->getHtml();
+
+		$this->assertStringContainsString( '<li>foo:bar</li>', $html );
+		$this->assertStringContainsString( '<li>bar:baz</li>', $html );
+		$this->assertStringNotContainsString( self::LOCAL_SETTINGS_MESSAGE, $html );
+	}
+
+	public function testHtmlContainsLocalSettingsAndWikiConfigPredicates(): void {
+		$presenter = new HtmlPredicatesPresenter();
+		$presenter->presentPredicates(
+			new PredicateList( [ new Predicate( 'foo:bar' ) ] ),
+			new PredicateList( [ new Predicate( 'bar:baz' ) ] )
+		);
+
+		$html = $presenter->getHtml();
+
+		$this->assertStringContainsString( '<li><span>foo:bar</span> <code>*</code></li>', $html );
+		$this->assertStringContainsString( '<li>bar:baz</li>', $html );
+		$this->assertStringContainsString( self::LOCAL_SETTINGS_MESSAGE, $html );
 	}
 
 	public function testHtmlContainsMessageIfNoPredicatesAreConfigured(): void {
-		$mappingList = new PredicateList();
 		$presenter = new HtmlPredicatesPresenter();
-		$presenter->presentPredicates( $mappingList );
+		$presenter->presentPredicates( new PredicateList(), new PredicateList() );
 
 		$html = $presenter->getHtml();
 
@@ -36,6 +68,7 @@ class HtmlPredicatesPresenterTest extends TestCase {
 			'No predicates are defined.',
 			$html
 		);
+		$this->assertStringNotContainsString( self::LOCAL_SETTINGS_MESSAGE, $html );
 	}
 
 }


### PR DESCRIPTION
Fixes #81

This displays the _combined_ predicates from LocalSettings and the page.
* Should we do that?
* Or show two lists?
* Or show only the predicates defined on the page?

----

With no predicates:
![Screenshot_20220821_170208](https://user-images.githubusercontent.com/1428594/185797424-539bcbd9-581b-41bd-8e8f-1b3c82d18194.png)

With one predicate:
![Screenshot_20220821_170317](https://user-images.githubusercontent.com/1428594/185797487-0af03df8-0377-4cbb-820d-ca9be55142be.png)

With multiple predicates:
![Screenshot_20220821_170344](https://user-images.githubusercontent.com/1428594/185797504-d4cd6487-e782-4af1-94e7-a7cca44ff329.png)

(Plural done for the same reason as #85)

