### PR TITLE
Fix suppressed CI warnings

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8,22 +8,6 @@
       <code>$array</code>
     </MixedAssignment>
   </file>
-  <file src="src/Presentation/HtmlPredicatesPresenter.php">
-    <MixedArgument occurrences="3">
-      <code>wfMessage( 'wikibase-rdf-config-list-empty' )-&gt;text()</code>
-      <code>wfMessage( 'wikibase-rdf-config-list-heading', $count )-&gt;text()</code>
-      <code>wfMessage( 'wikibase-rdf-config-list-intro' )-&gt;text()</code>
-    </MixedArgument>
-    <MixedMethodCall occurrences="4">
-      <code>text</code>
-      <code>text</code>
-      <code>text</code>
-      <code>text</code>
-    </MixedMethodCall>
-    <MixedOperand occurrences="1">
-      <code>wfMessage( 'wikibase-rdf-config-list-footer' )-&gt;text()</code>
-    </MixedOperand>
-  </file>
   <file src="src/WikibaseRdfExtension.php">
     <MixedArgumentTypeCoercion occurrences="1">
       <code>(array)$services-&gt;getMainConfig()-&gt;get( 'AvailableRights' )</code>

--- a/src/Presentation/HtmlMappingsPresenter.php
+++ b/src/Presentation/HtmlMappingsPresenter.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseRDF\Presentation;
 
 use Html;
+use Message;
 use ProfessionalWiki\WikibaseRDF\Application\MappingList;
 use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
 
@@ -38,8 +39,8 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 
 	private function createHeader(): string {
 		return '<thead id="wikibase-rdf-header"><tr>'
-			. '<th class="wikibase-rdf-mappings-predicate-heading">' . wfMessage( 'wikibase-rdf-mappings-predicate-heading' ) . '</th>'
-			. '<th class="wikibase-rdf-mappings-object-heading">' . wfMessage( 'wikibase-rdf-mappings-object-heading' ) . '</th>'
+			. '<th class="wikibase-rdf-mappings-predicate-heading">' . $this->msg( 'wikibase-rdf-mappings-predicate-heading' ) . '</th>'
+			. '<th class="wikibase-rdf-mappings-object-heading">' . $this->msg( 'wikibase-rdf-mappings-object-heading' ) . '</th>'
 			. '<th class="wikibase-rdf-mappings-actions-heading"></th>'
 			. '</tr></thead>';
 	}
@@ -56,9 +57,9 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 			. '<td class="wikibase-rdf-predicate">' . $this->createPredicateSelect() . '</td>'
 			. '<td class="wikibase-rdf-object"><input name="wikibase-rdf-object" value="" /></td>'
 			. '<td class="wikibase-rdf-actions">'
-			. '<a href="#" class="wikibase-rdf-action-save"><span class="icon"></span>' . wfMessage( 'wikibase-rdf-mappings-action-save' ) . '</a> '
-			. '<a href="#" class="wikibase-rdf-action-remove"><span class="icon"></span>' . wfMessage( 'wikibase-rdf-mappings-action-remove' ) . '</a> '
-			. '<a href="#" class="wikibase-rdf-action-cancel"><span class="icon"></span>' . wfMessage( 'wikibase-rdf-mappings-action-cancel' ) . '</a>'
+			. '<a href="#" class="wikibase-rdf-action-save"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-save' ) . '</a> '
+			. '<a href="#" class="wikibase-rdf-action-remove"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-remove' ) . '</a> '
+			. '<a href="#" class="wikibase-rdf-action-cancel"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-cancel' ) . '</a>'
 			. '</td>'
 			. '</tr>';
 	}
@@ -103,7 +104,7 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 		if ( !$canEdit ) {
 			return '';
 		}
-		return '<a href="#" class="wikibase-rdf-action-edit"><span class="icon"></span>' . wfMessage( 'wikibase-rdf-mappings-action-edit' ) . '</a>';
+		return '<a href="#" class="wikibase-rdf-action-edit"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-edit' ) . '</a>';
 	}
 
 	private function createFooter( bool $canEdit ): string {
@@ -111,12 +112,16 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 			return '';
 		}
 		return '<div class="wikibase-rdf-footer"><div class="wikibase-rdf-footer-actions">'
-			. '<a href="#" class="wikibase-rdf-action-add"><span class="icon"></span>' . wfMessage( 'wikibase-rdf-mappings-action-add' ) . '</a>'
+			. '<a href="#" class="wikibase-rdf-action-add"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-add' ) . '</a>'
 			. '</div></div>';
 	}
 
 	public function getHtml(): string {
 		return $this->response;
+	}
+
+	private function msg( string $key, mixed ...$params ): Message {
+		return new Message( $key, $params );
 	}
 
 }

--- a/src/Presentation/HtmlMappingsPresenter.php
+++ b/src/Presentation/HtmlMappingsPresenter.php
@@ -39,8 +39,8 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 
 	private function createHeader(): string {
 		return '<thead id="wikibase-rdf-header"><tr>'
-			. '<th class="wikibase-rdf-mappings-predicate-heading">' . $this->msg( 'wikibase-rdf-mappings-predicate-heading' ) . '</th>'
-			. '<th class="wikibase-rdf-mappings-object-heading">' . $this->msg( 'wikibase-rdf-mappings-object-heading' ) . '</th>'
+			. '<th class="wikibase-rdf-mappings-predicate-heading">' . $this->msg( 'wikibase-rdf-mappings-predicate-heading' )->escaped() . '</th>'
+			. '<th class="wikibase-rdf-mappings-object-heading">' . $this->msg( 'wikibase-rdf-mappings-object-heading' )->escaped() . '</th>'
 			. '<th class="wikibase-rdf-mappings-actions-heading"></th>'
 			. '</tr></thead>';
 	}
@@ -57,9 +57,9 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 			. '<td class="wikibase-rdf-predicate">' . $this->createPredicateSelect() . '</td>'
 			. '<td class="wikibase-rdf-object"><input name="wikibase-rdf-object" value="" /></td>'
 			. '<td class="wikibase-rdf-actions">'
-			. '<a href="#" class="wikibase-rdf-action-save"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-save' ) . '</a> '
-			. '<a href="#" class="wikibase-rdf-action-remove"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-remove' ) . '</a> '
-			. '<a href="#" class="wikibase-rdf-action-cancel"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-cancel' ) . '</a>'
+			. '<a href="#" class="wikibase-rdf-action-save"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-save' )->escaped() . '</a> '
+			. '<a href="#" class="wikibase-rdf-action-remove"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-remove' )->escaped() . '</a> '
+			. '<a href="#" class="wikibase-rdf-action-cancel"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-cancel' )->escaped() . '</a>'
 			. '</td>'
 			. '</tr>';
 	}
@@ -104,7 +104,7 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 		if ( !$canEdit ) {
 			return '';
 		}
-		return '<a href="#" class="wikibase-rdf-action-edit"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-edit' ) . '</a>';
+		return '<a href="#" class="wikibase-rdf-action-edit"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-edit' )->escaped() . '</a>';
 	}
 
 	private function createFooter( bool $canEdit ): string {
@@ -112,7 +112,7 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 			return '';
 		}
 		return '<div class="wikibase-rdf-footer"><div class="wikibase-rdf-footer-actions">'
-			. '<a href="#" class="wikibase-rdf-action-add"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-add' ) . '</a>'
+			. '<a href="#" class="wikibase-rdf-action-add"><span class="icon"></span>' . $this->msg( 'wikibase-rdf-mappings-action-add' )->escaped() . '</a>'
 			. '</div></div>';
 	}
 

--- a/src/Presentation/HtmlPredicatesPresenter.php
+++ b/src/Presentation/HtmlPredicatesPresenter.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseRDF\Presentation;
 
 use Html;
+use Message;
 use ProfessionalWiki\WikibaseRDF\Application\Predicate;
 use ProfessionalWiki\WikibaseRDF\Application\PredicateList;
 
@@ -23,7 +24,7 @@ class HtmlPredicatesPresenter implements PredicatesPresenter {
 	}
 
 	private function createIntro(): string {
-		return Html::rawElement( 'p', [], wfMessage( 'wikibase-rdf-config-list-intro' )->text() );
+		return Html::rawElement( 'p', [], $this->msg( 'wikibase-rdf-config-list-intro' )->text() );
 	}
 
 	private function createList(): string {
@@ -32,10 +33,10 @@ class HtmlPredicatesPresenter implements PredicatesPresenter {
 		$count = count( $localSettingsPredicates ) + count( $wikiPredicates );
 
 		if ( $count === 0 ) {
-			return Html::element( 'p', [], wfMessage( 'wikibase-rdf-config-list-empty' )->text() );
+			return Html::element( 'p', [], $this->msg( 'wikibase-rdf-config-list-empty' )->text() );
 		}
 
-		return Html::element( 'p', [], wfMessage( 'wikibase-rdf-config-list-heading', $count )->text() )
+		return Html::element( 'p', [], $this->msg( 'wikibase-rdf-config-list-heading', $count )->text() )
 			. Html::rawElement(
 				'ul',
 				[],
@@ -77,12 +78,16 @@ class HtmlPredicatesPresenter implements PredicatesPresenter {
 		return Html::rawElement(
 			'p',
 			[],
-			self::ASTERISK . ' ' . wfMessage( 'wikibase-rdf-config-list-footer' )->text()
+			self::ASTERISK . ' ' . $this->msg( 'wikibase-rdf-config-list-footer' )->text()
 		);
 	}
 
 	public function getHtml(): string {
 		return $this->response;
+	}
+
+	private function msg( string $key, mixed ...$params ): Message {
+		return new Message( $key, $params );
 	}
 
 }


### PR DESCRIPTION
From #87 

Replaces calls to the global `wfMessage` with local functions.

This is the simplest way to not just suppress the warnings. Otherwise we need to inject an `IContextSource` which is going to complicate testing.