### PR TITLE
Add performance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ cs: phpcs stan psalm
 phpunit:
 	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist
 
+perf:
+	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --group Performance
+
 phpcs:
 	cd ../.. && vendor/bin/phpcs -p -s --standard=$(shell pwd)/phpcs.xml
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,4 +9,9 @@
 			<directory suffix=".php">src</directory>
 		</whitelist>
 	</filter>
+	<groups>
+		<exclude>
+			<group>Performance</group>
+		</exclude>
+	</groups>
 </phpunit>

--- a/tests/Persistence/SqlAllMappingsLookupPerformanceTest.php
+++ b/tests/Persistence/SqlAllMappingsLookupPerformanceTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests\Persistence;
+
+use ProfessionalWiki\WikibaseRDF\Application\MappingListAndId;
+use ProfessionalWiki\WikibaseRDF\Application\Mapping;
+use ProfessionalWiki\WikibaseRDF\Application\MappingList;
+use ProfessionalWiki\WikibaseRDF\Persistence\SqlAllMappingsLookup;
+use ProfessionalWiki\WikibaseRDF\Tests\WikibaseRdfIntegrationTest;
+use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
+use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\Repo\WikibaseRepo;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseRDF\Persistence\SqlAllMappingsLookup
+ * @group Database
+ * @group Performance
+ */
+class SqlAllMappingsLookupPerformanceTest extends WikibaseRdfIntegrationTest {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->setAllowedPredicates( [ 'foo:bar' ] );
+	}
+
+	private function newSqlAllMappingsLookup(): SqlAllMappingsLookup {
+		return new SqlAllMappingsLookup(
+			$this->db,
+			WikibaseRdfExtension::SLOT_NAME,
+			WikibaseRepo::getEntityIdParser(),
+			WikibaseRdfExtension::getInstance()->newMappingListSerializer()
+		);
+	}
+
+	public function providePerformance(): iterable {
+		// Items, Mappings, Revisions, Expected Milliseconds
+		yield [ 1, 1, 1, 1 ];
+		yield [ 500, 1, 1, 10 ];
+		yield [ 1, 500, 1, 5 ];
+		yield [ 1, 1, 500, 1 ];
+		yield [ 50, 50, 50, 15 ];
+		yield [ 500, 100, 1, 100 ];
+	}
+
+	/**
+	 * @dataProvider providePerformance
+	 */
+	public function testPerformance( int $items, int $mappings, int $revisions, int $expectedTime ): void {
+		print( "\n$items items with $mappings mappings and $revisions revisions\n" );
+
+		$setupStart = hrtime( true );
+		for ( $i = 1; $i <= $items; $i++ ) {
+			$id = new ItemId( "Q$i" );
+			$this->createItem( $id );
+			$this->setMappingsRepeatedly( $id, $mappings, $revisions );
+		}
+
+		$lookup = $this->newSqlAllMappingsLookup();
+
+		$setupEnd = hrtime( true );
+		$setupTook = ( $setupEnd - $setupStart ) / 1000000000;
+		print( "Setup: {$setupTook}s\n" );
+
+		$start = hrtime( true );
+		$allMappings = $lookup->getAllMappings();
+		$end = hrtime( true );
+		$took = ( $end - $start ) / 1000000;
+
+		print( "Get all mappings: {$took}ms\n" );
+
+		$this->assertSame(
+			$items * $mappings,
+			array_sum(
+				array_map( fn( MappingListAndId $mapping ) => count( $mapping->mappingList->asArray() ), $allMappings )
+			)
+		);
+		$this->assertLessThan( $expectedTime, $took );
+	}
+
+	private function createBulkMappings( int $count, int $revision ): MappingList {
+		return new MappingList(
+			array_map(
+				fn( $i ) => new Mapping( 'foo:bar', "http://example.com/$i-$revision" ),
+				range( 0, $count - 1 )
+			)
+		);
+	}
+
+	private function setMappingsRepeatedly( EntityId $entityId, int $mappings, int $revisions ): void {
+		for ( $j = 0; $j < $revisions; $j++ ) {
+			$mappingList = $this->createBulkMappings( $mappings, $j );
+			$this->setMappings( $entityId, $mappingList );
+		}
+	}
+
+	protected function setMappings( EntityId $entityId, MappingList $mappingList ): void {
+		$user = self::getTestSysop()->getUser();
+		WikibaseRdfExtension::getInstance()->newMappingRepository( $user )->setMappings( $entityId, $mappingList );
+	}
+
+}


### PR DESCRIPTION
Refs #61 

This is excluded from the normal unit tests because it takes ~15 minutes. There's probably a more efficient way to setup the test data, but this works for now.

This includes some arbitrary expected times based on my laptop's performance.

Run with:
```
make perf
```

Example:
![Screenshot_20220825_115905](https://user-images.githubusercontent.com/1428594/186635677-8984ad1c-d4dc-430f-b316-9359b69cc0cc.png)

