### PR TITLE
Export things not strings

### DIFF
--- a/src/Presentation/RDF/MappingRdfBuilder.php
+++ b/src/Presentation/RDF/MappingRdfBuilder.php
@@ -51,7 +51,7 @@ class MappingRdfBuilder implements EntityRdfBuilder {
 	private function addMapping( Mapping $mapping ): void {
 		$this->writer
 			->say( $mapping->getPredicateBase(), $mapping->getPredicateLocal() )
-			->text( $mapping->object );
+			->is( $mapping->object );
 	}
 
 }


### PR DESCRIPTION
Fixes #93 

`text()` vs `is()` seems to be the "string" vs "thing" difference.

I believe using the full URL is fine when passing only the first parameter of `is()`. However, if we need to support the `foo:bar` syntax then we might need to also break up base and local like with the predicate.