### PR TITLE
Don't fail when retrieving invalid mappings

### DIFF
--- a/src/MappingListSerializer.php
+++ b/src/MappingListSerializer.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF;
 
+use InvalidArgumentException;
 use ProfessionalWiki\WikibaseRDF\Application\Mapping;
 use ProfessionalWiki\WikibaseRDF\Application\MappingList;
 
@@ -16,7 +17,7 @@ class MappingListSerializer {
 		$array = json_decode( $json, true );
 
 		if ( is_array( $array ) ) {
-			return $this->mappingListFromArray( $array );
+			return $this->validMappingListFromArray( $array );
 		}
 
 		return new MappingList();
@@ -35,6 +36,23 @@ class MappingListSerializer {
 				$mappings
 			)
 		);
+	}
+
+	/**
+	 * @param array<int, array{predicate: string, object: string}> $mappings
+	 */
+	public function validMappingListFromArray( array $mappings ): MappingList {
+		$mappingObjects = [];
+		foreach ( $mappings as $mapping ) {
+			try {
+				$mappingObjects[] = new Mapping(
+					predicate: $mapping[self::PREDICATE_KEY],
+					object: $mapping[self::OBJECT_KEY]
+				);
+			} catch ( InvalidArgumentException ) {
+			}
+		}
+		return new MappingList( $mappingObjects );
 	}
 
 	public function toJson( MappingList $mappingList ): string {

--- a/tests/MappingListSerializerTest.php
+++ b/tests/MappingListSerializerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\WikibaseRDF\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\WikibaseRDF\Application\Mapping;
+use ProfessionalWiki\WikibaseRDF\Application\MappingList;
+use ProfessionalWiki\WikibaseRDF\MappingListSerializer;
+
+/**
+ * @covers \ProfessionalWiki\WikibaseRDF\MappingListSerializer
+ */
+class MappingListSerializerTest extends TestCase {
+
+	public function testMappingListFromArrayWithValidMappings(): void {
+		$serializer = new MappingListSerializer();
+
+		$mappings = $serializer->mappingListFromArray( [
+			[ 'predicate' => 'foo:Bar', 'object' => 'https://example.com' ],
+			[ 'predicate' => 'bar:Baz', 'object' => 'https://test.com' ],
+		] );
+
+		$this->assertEquals(
+			new MappingList( [
+				new Mapping( 'foo:Bar', 'https://example.com' ),
+				new Mapping( 'bar:Baz', 'https://test.com' )
+			] ),
+			$mappings
+		);
+	}
+
+	public function testMappingListFromArrayWithInvalidMappingsThrowsException(): void {
+		$serializer = new MappingListSerializer();
+
+		$this->expectException( InvalidArgumentException::class );
+
+		$serializer->mappingListFromArray( [
+			[ 'predicate' => 'foo:Bar', 'object' => 'https://example.com' ],
+			[ 'predicate' => 'bar:Baz', 'object' => 'not:valid' ],
+		] );
+	}
+
+	public function testValidMappingListFromArrayWithValidMappings(): void {
+		$serializer = new MappingListSerializer();
+
+		$mappings = $serializer->validMappingListFromArray( [
+			[ 'predicate' => 'foo:Bar', 'object' => 'https://example.com' ],
+			[ 'predicate' => 'bar:Baz', 'object' => 'https://test.com' ],
+		] );
+
+		$this->assertEquals(
+			new MappingList( [
+				new Mapping( 'foo:Bar', 'https://example.com' ),
+				new Mapping( 'bar:Baz', 'https://test.com' )
+			] ),
+			$mappings
+		);
+	}
+
+	public function testValidMappingListFromArrayWithInvalidMappingsDoesNotThrowException(): void {
+		$serializer = new MappingListSerializer();
+
+		$mappings = $serializer->validMappingListFromArray( [
+			[ 'predicate' => 'foo:Bar', 'object' => 'https://example.com' ],
+			[ 'predicate' => 'bar:Baz', 'object' => 'not:valid' ],
+		] );
+
+		$this->assertEquals(
+			new MappingList( [
+				new Mapping( 'foo:Bar', 'https://example.com' ),
+			] ),
+			$mappings
+		);
+	}
+
+}


### PR DESCRIPTION
Fixes #99 

Simple implementatin of an additional method.

One side-effect, although probably harmless, is once you edit the mappings again it's going to overwrite (i.e. remove) the invalid mapping.