### PR TITLE
Add simple fix for Property RDF mappings

### DIFF
--- a/src/Presentation/RDF/MappingRdfBuilder.php
+++ b/src/Presentation/RDF/MappingRdfBuilder.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\WikibaseRDF\Presentation\RDF;
 use ProfessionalWiki\WikibaseRDF\Application\Mapping;
 use ProfessionalWiki\WikibaseRDF\Application\MappingRepository;
 use Wikibase\DataModel\Entity\EntityDocument;
+use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\Property;
 use Wikibase\Repo\Rdf\EntityRdfBuilder;
 use Wikimedia\Purtle\RdfWriter;
@@ -51,8 +52,14 @@ class MappingRdfBuilder implements EntityRdfBuilder {
 	 * @param Mapping[] $mappings
 	 */
 	private function addPropertyMappings( array $mappings, EntityDocument $entity ): void {
+		$id = $entity->getId();
+
+		if ( $id === null ) {
+			return;
+		}
+
 		foreach ( $mappings as $mapping ) {
-			$this->addPropertyMapping( $mapping, $entity );
+			$this->addPropertyMapping( $mapping, $id );
 		}
 	}
 
@@ -75,15 +82,9 @@ class MappingRdfBuilder implements EntityRdfBuilder {
 			->is( $mapping->object );
 	}
 
-	private function addPropertyMapping( Mapping $mapping, EntityDocument $entity ): void {
-		$id = $entity->getId();
-
-		if ( $id === null ) {
-			return;
-		}
-
+	private function addPropertyMapping( Mapping $mapping, EntityId $entityId ): void {
 		$this->writer
-			->about( 'wdt', $id->getLocalPart() )
+			->about( 'wdt', $entityId->getLocalPart() )
 			->a( 'owl', 'ObjectProperty' )
 			->say( $mapping->getPredicateBase(), $mapping->getPredicateLocal() )
 			->is( $mapping->object );

--- a/src/Presentation/RDF/MappingRdfBuilder.php
+++ b/src/Presentation/RDF/MappingRdfBuilder.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\WikibaseRDF\Presentation\RDF;
 use ProfessionalWiki\WikibaseRDF\Application\Mapping;
 use ProfessionalWiki\WikibaseRDF\Application\MappingRepository;
 use Wikibase\DataModel\Entity\EntityDocument;
+use Wikibase\DataModel\Entity\Property;
 use Wikibase\Repo\Rdf\EntityRdfBuilder;
 use Wikimedia\Purtle\RdfWriter;
 
@@ -30,8 +31,28 @@ class MappingRdfBuilder implements EntityRdfBuilder {
 //			$this->vocabulary->getEntityLName( $entity->getId() )
 //		);
 
+		if ( $entity->getType() === Property::ENTITY_TYPE ) {
+			$this->addPropertyMappings( $mappings, $entity );
+		} else {
+			$this->addItemMappings( $mappings );
+		}
+	}
+
+	/**
+	 * @param Mapping[] $mappings
+	 */
+	private function addItemMappings( array $mappings ): void {
 		foreach ( $mappings as $mapping ) {
-			$this->addMapping( $mapping );
+			$this->addItemMapping( $mapping );
+		}
+	}
+
+	/**
+	 * @param Mapping[] $mappings
+	 */
+	private function addPropertyMappings( array $mappings, EntityDocument $entity ): void {
+		foreach ( $mappings as $mapping ) {
+			$this->addPropertyMapping( $mapping, $entity );
 		}
 	}
 
@@ -48,8 +69,22 @@ class MappingRdfBuilder implements EntityRdfBuilder {
 		return $this->repository->getMappings( $id )->asArray();
 	}
 
-	private function addMapping( Mapping $mapping ): void {
+	private function addItemMapping( Mapping $mapping ): void {
 		$this->writer
+			->say( $mapping->getPredicateBase(), $mapping->getPredicateLocal() )
+			->is( $mapping->object );
+	}
+
+	private function addPropertyMapping( Mapping $mapping, EntityDocument $entity ): void {
+		$id = $entity->getId();
+
+		if ( $id === null ) {
+			return;
+		}
+
+		$this->writer
+			->about( 'wdt', $id->getLocalPart() )
+			->a( 'owl', 'ObjectProperty' )
 			->say( $mapping->getPredicateBase(), $mapping->getPredicateLocal() )
 			->is( $mapping->object );
 	}


### PR DESCRIPTION
Refs #100 

This is the simplest implementation that produces the example output as per https://github.com/ProfessionalWiki/WikibaseRDF/discussions/98#discussioncomment-3692976.

There are two possible issues with this implementation, although they might not be critical.

**Duplicate node issue:**
This is caused because the original "empty" `wdt` node is created by Wikibase here:
https://github.com/wikimedia/Wikibase/blob/master/repo/includes/Rdf/PropertySpecificComponentsRdfBuilder.php#L143-L146

I cannot find a way to inject anything there and my understanding is the RDF output is a stream, so you can only append. However, the resultant ttl file validates on something like http://ttl.summerofcode.be/, so I don't know if this is really a problem.

**Configurability issue:**
It seems to be possible to use a different prefix instead of `wdt`:
https://doc.wikimedia.org/Wikibase/master/php/md_docs_topics_entitysources.html
Refer to 'rdfNodeNamespacePrefix'.
There is a hacky way we can get the `wd` part of the prefix from WB settings and then we can append the `t` using a WB constant. However, I'm not sure if there is some other magic that happens in the background and in such a case it would probably be better to do something similar to what WB's `PropertySpecificComponentsRdfBuilder` does.

----

If we need to expand on the Property mapping logic, e.g. by injecting the same dependencies used by `PropertySpecificComponentsRdfBuilder`, would it make more sense to have two implementations of our `EntityRdfBuilder` to keep Item and Property logic separate?
