### PR TITLE
Render object URL as link

### DIFF
--- a/resources/ext.wikibase.rdf.js
+++ b/resources/ext.wikibase.rdf.js
@@ -56,6 +56,14 @@ $( function () {
 		$( '.wikibase-rdf-error' ).text( error ).show();
 	}
 
+	function createObjectLink( url ) {
+		const link = document.createElement( 'a' );
+		link.href = url;
+		link.text = url;
+		link.classList.add( 'external' );
+		return $( link );
+	}
+
 	function onSuccessfulSave( trigger ) {
 		console.log( 'onSuccessfulSave' );
 		const $row = findRow( trigger );
@@ -67,7 +75,7 @@ $( function () {
 
 		$row.html( $( '.wikibase-rdf-row-template' ).html() );
 		$row.find( '.wikibase-rdf-predicate' ).text( $row.data( 'predicate' ) );
-		$row.find( '.wikibase-rdf-object' ).text( $row.data( 'object' ) );
+		$row.find( '.wikibase-rdf-object' ).append( createObjectLink( $row.data( 'object' ) ) );
 	}
 
 	function onSuccessfulRemove( trigger ) {

--- a/src/Presentation/HtmlMappingsPresenter.php
+++ b/src/Presentation/HtmlMappingsPresenter.php
@@ -95,9 +95,13 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 			'tr',
 			[ 'class' => 'wikibase-rdf-row', 'data-predicate' => $relationship, 'data-object' => $url ],
 			Html::element( 'td', [ 'class' => 'wikibase-rdf-predicate' ], $relationship )
-				. Html::element( 'td', [ 'class' => 'wikibase-rdf-object' ], $url )
+				. Html::rawElement( 'td', [ 'class' => 'wikibase-rdf-object' ], $this->createObjectLink( $url ) )
 				. Html::rawElement( 'td', [ 'class' => 'wikibase-rdf-actions' ], $this->createEditButton( $canEdit ) )
 		);
+	}
+
+	private function createObjectLink( string $url ): string {
+		return Html::element( 'a', [ 'href' => $url, 'rel' => 'nofollow', 'class' => 'external' ], $url );
 	}
 
 	private function createEditButton( bool $canEdit ): string {

--- a/tests/Presentation/HtmlMappingsPresenterTest.php
+++ b/tests/Presentation/HtmlMappingsPresenterTest.php
@@ -46,6 +46,19 @@ class HtmlMappingsPresenterTest extends TestCase {
 		$this->assertStringContainsString( $mapping2->object, $html );
 	}
 
+	public function testMappingUrlIsALink(): void {
+		$presenter = new HtmlMappingsPresenter( $this->getAllowedPredicates(), false );
+		$mapping = new Mapping( 'owl:sameAs', 'http://www.w3.org/2000/01/rdf-schema#subClassOf' );
+
+		$presenter->showMappings(
+			new MappingList( [ $mapping ] ),
+			true
+		);
+		$html = $presenter->getHtml();
+
+		$this->assertStringContainsString( '<a href="' . $mapping->object . '"', $html );
+	}
+
 	public function testEditActionsAreDisplayed(): void {
 		$presenter = new HtmlMappingsPresenter( $this->getAllowedPredicates(), false );
 		$mapping1 = new Mapping( 'owl:sameAs', 'http://www.w3.org/2000/01/rdf-schema#subClassOf' );


### PR DESCRIPTION
Fixes #103 

![Screenshot_20220928_214739](https://user-images.githubusercontent.com/1428594/192875004-750e0d1e-f2f2-4b1a-a3ef-bfd58673c760.png)

On initial page render `rel="nofollow"` is added, but when an edit is done it is not added because it's irrelevant until the page is reloaded.