### PR TITLE
Use relative path for icons

### DIFF
--- a/resources/ext.wikibase.rdf.less
+++ b/resources/ext.wikibase.rdf.less
@@ -83,33 +83,33 @@
 
 // TODO: check if these urls work if the wiki is on a subpath
 .wikibase-rdf-action-edit .icon {
-	background-image: url( /extensions/Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/edit.png );
+	background-image: url( ../../Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/edit.png );
 	/* @embed */
-	background-image: linear-gradient( transparent, transparent ), url( /extensions/Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/edit.svg );
+	background-image: linear-gradient( transparent, transparent ), url( ../../Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/edit.svg );
 }
 
 .wikibase-rdf-action-save .icon {
-	background-image: url( /extensions/Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/check.png );
+	background-image: url( ../../Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/check.png );
 	/* @embed */
-	background-image: linear-gradient( transparent, transparent ), url( /extensions/Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/check.svg );
+	background-image: linear-gradient( transparent, transparent ), url( ../../Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/check.svg );
 }
 
 .wikibase-rdf-action-remove .icon {
-	background-image: url( /extensions/Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/trash.png );
+	background-image: url( ../../Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/trash.png );
 	/* @embed */
-	background-image: linear-gradient( transparent, transparent ), url( /extensions/Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/trash.svg );
+	background-image: linear-gradient( transparent, transparent ), url( ../../Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/trash.svg );
 }
 
 .wikibase-rdf-action-cancel .icon {
-	background-image: url( /extensions/Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/close.png );
+	background-image: url( ../../Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/close.png );
 	/* @embed */
-	background-image: linear-gradient( transparent, transparent ), url( /extensions/Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/close.svg );
+	background-image: linear-gradient( transparent, transparent ), url( ../../Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/close.svg );
 }
 
 .wikibase-rdf-action-add .icon {
-	background-image: url( /extensions/Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/add.png );
+	background-image: url( ../../Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/add.png );
 	/* @embed */
-	background-image: linear-gradient( transparent, transparent ), url( /extensions/Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/add.svg );
+	background-image: linear-gradient( transparent, transparent ), url( ../../Wikibase/view/resources/jquery/wikibase/toolbar/themes/default/images/icons/ooui/add.svg );
 }
 
 .wikibase-rdf-footer {


### PR DESCRIPTION
Refs #108 

The problem had to do with the `/w` vs `/wiki` base path.

This change is working locally, but we need to deploy it first to test it in production.