### PR TITLE
Make linting pass and add to CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
 	"rules": {
 		"no-jquery/no-parse-html-literal": "warn",
 		"no-jquery/no-global-selector": "warn",
+		"no-jquery/no-class-state": "warn",
 		"mediawiki/msg-doc": "warn"
 	}
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,3 +246,16 @@ jobs:
         run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
 
       - run: vendor/bin/phpcs -p -s
+        
+  linting:
+    name: "Linting"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm install
+      - run: npm run test

--- a/resources/ext.wikibase.rdf.js
+++ b/resources/ext.wikibase.rdf.js
@@ -7,13 +7,13 @@ $( function () {
 
 	function moveSection() {
 		// Move Mappings before Statements section.
-		$( '#wikibase-rdf' ).insertBefore( $( 'h2.wikibase-statements' ) ).show();
+		$( '.wikibase-rdf' ).insertBefore( $( 'h2.wikibase-statements' ) ).show();
 	}
 
 	function addToggler() {
 		// TODO: toggler state needs to be remembered.
-		const toggler = $( '#wikibase-rdf-toggler' ).toggler( {
-			$subject: $( '#wikibase-rdf-mappings' ),
+		const toggler = $( '.wikibase-rdf-toggler' ).toggler( {
+			$subject: $( '.wikibase-rdf-mappings' ),
 			visible: false
 		} );
 		toggler.find( '.ui-toggler-label' ).text( mw.msg( 'wikibase-rdf-mappings-toggler' ) );
@@ -141,11 +141,11 @@ $( function () {
 	}
 
 	function disableActions() {
-		$( '#wikibase-rdf' ).addClass( 'wikibase-rdf-disabled' );
+		$( '.wikibase-rdf' ).addClass( 'wikibase-rdf-disabled' );
 	}
 
 	function enableActions() {
-		$( '#wikibase-rdf' ).removeClass( 'wikibase-rdf-disabled' );
+		$( '.wikibase-rdf' ).removeClass( 'wikibase-rdf-disabled' );
 	}
 
 	function saveMappings( trigger ) {
@@ -247,7 +247,7 @@ $( function () {
 
 	function setupEvents() {
 		$( '.wikibase-rdf-action-add' ).on( 'click', clickAdd );
-		$( '#wikibase-rdf' )
+		$( '.wikibase-rdf' )
 			.on( 'click', '.wikibase-rdf-action-edit', clickEdit )
 			.on( 'click', '.wikibase-rdf-action-save', clickSave )
 			.on( 'click', '.wikibase-rdf-action-remove', clickRemove )

--- a/resources/ext.wikibase.rdf.less
+++ b/resources/ext.wikibase.rdf.less
@@ -1,11 +1,11 @@
 @import 'mediawiki.ui/variables';
 
-#wikibase-rdf {
+.wikibase-rdf {
 	float: left;
 	width: 100%;
 }
 
-#wikibase-rdf-mappings table {
+.wikibase-rdf-mappings table {
 	background: #fff;
 	border: 1px solid #c8ccd1;
 	border-spacing: 0;
@@ -15,7 +15,7 @@
 	word-wrap: break-word;
 }
 
-#wikibase-rdf-header th {
+.wikibase-rdf-header th {
 	background-color: #eaecf0;
 	border-right: 1px solid #fff;
 	padding: 0 0 0 0.4em;
@@ -70,7 +70,7 @@
 	font-size: small;
 }
 
-#wikibase-rdf .icon {
+.wikibase-rdf .icon {
 	background-position: center;
 	background-repeat: no-repeat;
 	background-size: 16px 16px;

--- a/src/Presentation/HtmlMappingsPresenter.php
+++ b/src/Presentation/HtmlMappingsPresenter.php
@@ -20,9 +20,9 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 	}
 
 	public function showMappings( MappingList $mappingList, bool $canEdit ): void {
-		$this->response = '<div id="wikibase-rdf" style="display: none;">'
-			. '<div id="wikibase-rdf-toggler"></div>'
-			. '<div class id="wikibase-rdf-mappings">'
+		$this->response = '<div class="wikibase-rdf" style="display: none;">'
+			. '<div class="wikibase-rdf-toggler"></div>'
+			. '<div class="wikibase-rdf-mappings">'
 			. '<table>'
 			. $this->createHeader()
 			. '<tbody class="wikibase-rdf-rows">'
@@ -38,7 +38,7 @@ class HtmlMappingsPresenter implements MappingsPresenter {
 	}
 
 	private function createHeader(): string {
-		return '<thead id="wikibase-rdf-header"><tr>'
+		return '<thead class="wikibase-rdf-header"><tr>'
 			. '<th class="wikibase-rdf-mappings-predicate-heading">' . $this->msg( 'wikibase-rdf-mappings-predicate-heading' )->escaped() . '</th>'
 			. '<th class="wikibase-rdf-mappings-object-heading">' . $this->msg( 'wikibase-rdf-mappings-object-heading' )->escaped() . '</th>'
 			. '<th class="wikibase-rdf-mappings-actions-heading"></th>'


### PR DESCRIPTION
Fixes #67 (in so far as it disables the one check that makes it fail).

The "no-jquery/no-class-state" rule's warning level must be removed in #77.

There are no functional changes here. This just fixes whatever ESLint and Stylelint complained about, excludng the above rule.