### PR TITLE
Run CI on MW 1.38

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
         include:
           - mw: 'REL1_37'
             php: '8.0'
+          - mw: 'REL1_38'
+            php: '8.0'
 
     runs-on: ubuntu-latest
 
@@ -246,7 +248,7 @@ jobs:
         run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
 
       - run: vendor/bin/phpcs -p -s
-        
+
   linting:
     name: "Linting"
 

--- a/tests/Persistence/SqlAllMappingsLookupTest.php
+++ b/tests/Persistence/SqlAllMappingsLookupTest.php
@@ -11,6 +11,7 @@ use ProfessionalWiki\WikibaseRDF\Persistence\SqlAllMappingsLookup;
 use ProfessionalWiki\WikibaseRDF\Tests\WikibaseRdfIntegrationTest;
 use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
 use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\NumericPropertyId;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\Repo\WikibaseRepo;
 
@@ -35,6 +36,13 @@ class SqlAllMappingsLookupTest extends WikibaseRdfIntegrationTest {
 		);
 	}
 
+	private function createPropertyId( string $id ): PropertyId {
+		if ( class_exists( PropertyId::class ) ) {
+			return new PropertyId( $id );
+		}
+		return new NumericPropertyId( $id );
+	}
+
 	private function saveTestMappings(): void {
 		$this->createItem( new ItemId( 'Q99001' ) );
 		$this->createItemWithMappings(
@@ -51,15 +59,15 @@ class SqlAllMappingsLookupTest extends WikibaseRdfIntegrationTest {
 				new Mapping( 'foo:baz', 'https://example.com/#baz1' )
 			] )
 		);
-		$this->createProperty( new PropertyId( 'P99001' ) );
+		$this->createProperty( $this->createPropertyId( 'P99001' ) );
 		$this->createPropertyWithMappings(
-			new PropertyId( 'P99002' ),
+			$this->createPropertyId( 'P99002' ),
 			new MappingList( [
 				new Mapping( 'foo:foo', 'https://example.com/#foo1' )
 			] )
 		);
 		$this->createPropertyWithMappings(
-			new PropertyId( 'P99003' ),
+			$this->createPropertyId( 'P99003' ),
 			new MappingList( [
 				new Mapping( 'foo:foo', 'https://example.com/#foo1' ),
 				new Mapping( 'foo:bar', 'https://example.com/#bar1' ),
@@ -85,13 +93,13 @@ class SqlAllMappingsLookupTest extends WikibaseRdfIntegrationTest {
 				] )
 			),
 			new MappingListAndId(
-				new PropertyId( 'P99002' ),
+				$this->createPropertyId( 'P99002' ),
 				new MappingList( [
 					new Mapping( 'foo:foo', 'https://example.com/#foo1' )
 				] )
 			),
 			new MappingListAndId(
-				new PropertyId( 'P99003' ),
+				$this->createPropertyId( 'P99003' ),
 				new MappingList( [
 					new Mapping( 'foo:foo', 'https://example.com/#foo1' ),
 					new Mapping( 'foo:bar', 'https://example.com/#bar1' ),
@@ -130,7 +138,7 @@ class SqlAllMappingsLookupTest extends WikibaseRdfIntegrationTest {
 			] )
 		);
 		$this->setMappings(
-			new PropertyId( 'P99002' ),
+			$this->createPropertyId( 'P99002' ),
 			new MappingList( [
 				new Mapping( 'foo:foo', 'https://example.com/#foo2' ),
 				new Mapping( 'foo:baz', 'https://example.com/#baz2' )
@@ -159,14 +167,14 @@ class SqlAllMappingsLookupTest extends WikibaseRdfIntegrationTest {
 					] )
 				),
 				new MappingListAndId(
-					new PropertyId( 'P99002' ),
+					$this->createPropertyId( 'P99002' ),
 					new MappingList( [
 						new Mapping( 'foo:foo', 'https://example.com/#foo2' ),
 						new Mapping( 'foo:baz', 'https://example.com/#baz2' )
 					] )
 				),
 				new MappingListAndId(
-					new PropertyId( 'P99003' ),
+					$this->createPropertyId( 'P99003' ),
 					new MappingList( [
 						new Mapping( 'foo:foo', 'https://example.com/#foo1' ),
 						new Mapping( 'foo:bar', 'https://example.com/#bar1' ),


### PR DESCRIPTION
This is not to add official 1.38 support. Rather, this was done while debugging https://github.com/ProfessionalWiki/WikibaseExport/issues/161 and the PHP 8.1 issue there.

Summary:
* MW 1.38 + PHP 8.1 fails with the same DB update error here
* MW 1.39 has API response message related issues which I am not going to spend time on now