### PR TITLE
Remove deprecated 'mediawiki.ui/variables.less' import

### DIFF
--- a/resources/ext.wikibase.rdf.less
+++ b/resources/ext.wikibase.rdf.less
@@ -1,5 +1,3 @@
-@import 'mediawiki.ui/variables';
-
 .wikibase-rdf {
 	float: left;
 	width: 100%;
@@ -42,7 +40,7 @@
 }
 
 .wikibase-rdf-error {
-	color: @color-destructive;
+	color: #d33;
 }
 
 .wikibase-rdf-disabled a {


### PR DESCRIPTION
styles: Replace 'mediawiki.ui/variables' call with skin variables

Removing 'mediawiki.ui/variables.less' `@import`.  Alternative to going back to static color value would be new skin-aware 'mediawiki.skin.variables.less' standard. But that would result in a bump of minimum required MediaWiki core version to >= v1.41.0. As I don't know the use case of this extension too well, removing and replacing one color with a static value seems like the simpler way forward right now.

Bug: T332541
Depends-On: I04f9e48a1cf9dee915cf51e1e12b17ff0a595a06