### PR TITLE
T365757: Use body parameters instead of JSON body validator

### DIFF
--- a/src/EntryPoints/Rest/SaveMappingsApi.php
+++ b/src/EntryPoints/Rest/SaveMappingsApi.php
@@ -42,19 +42,8 @@ class SaveMappingsApi extends SimpleHandler {
 		];
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	public function getBodyValidator( $contentType ): BodyValidator {
-		if ( $contentType !== 'application/json' ) {
-			throw new HttpException(
-				"Unsupported Content-Type",
-				415,
-				[ 'content_type' => $contentType ]
-			);
-		}
-
-		return new JsonBodyValidator( [] );
+	public function getBodyParamSettings(): array {
+		return [];
 	}
 
 }


### PR DESCRIPTION
The use of body validator is deprecated in the REST API framework. See T365757