### PR TITLE
Add support for MW 1.43 and drop older support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             mediawiki

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,21 @@ jobs:
     name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
 
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - mw: 'REL1_37'
-            php: '8.0'
-          - mw: 'REL1_38'
-            php: '8.0'
-          - mw: 'REL1_39'
-            php: '8.0'
+          - mw: 'REL1_43'
+            php: 8.1
+            experimental: false
+          - mw: 'REL1_43'
+            php: 8.2
+            experimental: false
+          - mw: 'REL1_43'
+            php: 8.3
+            experimental: false
+          - mw: 'master'
+            php: 8.4
+            experimental: true
 
     runs-on: ubuntu-latest
 
@@ -34,21 +41,21 @@ jobs:
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v3
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v4
 
       - name: Cache Composer cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: composer-php${{ matrix.php }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
             path: EarlyCopy
 
@@ -57,7 +64,7 @@ jobs:
         working-directory: ~
         run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} WikibaseRDF
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: mediawiki/extensions/WikibaseRDF
 
@@ -71,21 +78,27 @@ jobs:
 
       - name: Run PHPUnit
         run: php tests/phpunit/phpunit.php -c extensions/WikibaseRDF/
-        if: matrix.php != '8.0'
+        if: matrix.mw != 'master'
 
       - name: Run PHPUnit with code coverage
         run: php tests/phpunit/phpunit.php -c extensions/WikibaseRDF/ --coverage-clover coverage.xml
-        if: matrix.php == '8.0'
+        if: matrix.mw != 'master'
 
       - name: Upload code coverage
         run: bash <(curl -s https://codecov.io/bash)
-        if: matrix.php == '8.0' && github.ref == 'refs/heads/master'
+        if: matrix.mw == 'master'
 
 
 
 
   PHPStan:
     name: "PHPStan"
+
+    strategy:
+      matrix:
+        include:
+          - mw: 'REL1_43'
+            php: '8.3'
 
     runs-on: ubuntu-latest
 
@@ -97,7 +110,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: ${{ matrix.php }}
           extensions: mbstring
           tools: composer, cs2pr
 
@@ -109,24 +122,24 @@ jobs:
             mediawiki
             mediawiki/extensions/
             mediawiki/vendor/
-          key: mw_phpstan
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v4
 
       - name: Cache Composer cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: composer_static_analysis
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
             path: EarlyCopy
 
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
-        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh REL1_37 WikibaseRDF
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} WikibaseRDF
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: mediawiki/extensions/WikibaseRDF
 
@@ -145,7 +158,13 @@ jobs:
 
 
   Psalm:
-      name: "Psalm"
+      name: "Psalm: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+
+      strategy:
+        matrix:
+          include:
+            - mw: 'REL1_43'
+              php: '8.3'
 
       runs-on: ubuntu-latest
 
@@ -157,36 +176,36 @@ jobs:
           - name: Setup PHP
             uses: shivammathur/setup-php@v2
             with:
-                php-version: 8.0
+                php-version: ${{ matrix.php }}
                 extensions: mbstring
                 tools: composer, cs2pr
 
           - name: Cache MediaWiki
             id: cache-mediawiki
-            uses: actions/cache@v2
+            uses: actions/cache@v4
             with:
                 path: |
                     mediawiki
                     mediawiki/extensions/
                     mediawiki/vendor/
-                key: mw_psalm
+                key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v4
 
           - name: Cache Composer cache
-            uses: actions/cache@v2
+            uses: actions/cache@v4
             with:
                 path: ~/.composer/cache
                 key: composer_static_analysis
 
-          - uses: actions/checkout@v2
+          - uses: actions/checkout@v4
             with:
                 path: EarlyCopy
 
           - name: Install MediaWiki
             if: steps.cache-mediawiki.outputs.cache-hit != 'true'
             working-directory: ~
-            run: bash EarlyCopy/.github/workflows/installMediaWiki.sh REL1_37 WikibaseRDF
+            run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} WikibaseRDF
 
-          - uses: actions/checkout@v2
+          - uses: actions/checkout@v4
             with:
                 path: mediawiki/extensions/WikibaseRDF
 
@@ -205,7 +224,13 @@ jobs:
 
 
   code-style:
-    name: "Code style"
+    name: "Code style: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+
+    strategy:
+      matrix:
+        include:
+          - mw: 'REL1_43'
+            php: '8.3'
 
     runs-on: ubuntu-latest
 
@@ -217,13 +242,13 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: ${{ matrix.php }}
           extensions: mbstring, intl, php-ast
           tools: composer
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             mediawiki
@@ -232,17 +257,21 @@ jobs:
           key: mw_static_analysis
 
       - name: Cache Composer cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: composer_static_analysis
 
+      - uses: actions/checkout@v4
+        with:
+            path: EarlyCopy
+
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
-        run: curl https://gist.githubusercontent.com/JeroenDeDauw/49a3858653ff4b5be7ec849019ede06c/raw/installMediaWiki.sh | bash -s REL1_37 WikibaseRDF
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} WikibaseRDF
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: mediawiki/extensions/WikibaseRDF
 
@@ -257,9 +286,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
       - run: npm install
       - run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .phpunit.result.cache
 composer.lock
+vendor/

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,16 @@ perf:
 	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --group Performance
 
 phpcs:
-	cd ../.. && vendor/bin/phpcs -p -s --standard=$(shell pwd)/phpcs.xml
+	vendor/bin/phpcs -p -s --standard=$(shell pwd)/phpcs.xml
 
 stan:
-	../../vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=2G
+	vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=2G
 
 stan-baseline:
-	../../vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=2G --generate-baseline
+	vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=2G --generate-baseline
 
 psalm:
-	../../vendor/bin/psalm --config=psalm.xml
+	vendor/bin/psalm --config=psalm.xml
 
 psalm-baseline:
-	../../vendor/bin/psalm --config=psalm.xml --set-baseline=psalm-baseline.xml
+	vendor/bin/psalm --config=psalm.xml --set-baseline=psalm-baseline.xml

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ For more information, refer to the [REST API documentation](docs/rest.md).
 Platform requirements:
 
 * [PHP] 8.0 or later (tested up to 8.1)
-* [MediaWiki] 1.37 or later (tested up to 1.37)
-* [Wikibase] 1.37 or later (tested up to 1.37)
+* [MediaWiki] 1.43 or later (tested up to 1.43)
+* [Wikibase] 1.43 or later (tested up to 1.43)
 
 The recommended way to install Wikibase RDF is using [Composer] with
 [MediaWiki's built-in support for Composer][Composer install].

--- a/WikibaseRdf.alias.php
+++ b/WikibaseRdf.alias.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Aliases for special pages
+ *
+ * @file
+ * @ingroup Extensions
+ */
+
+$specialPageAliases = [];
+
+/** English (English) */
+$specialPageAliases['en'] = [
+	'MappingPredicates' => [ 'MappingPredicates' ]
+];

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"composer/installers": "^2|^1.0.1"
 	},
 	"require-dev": {
-		"vimeo/psalm": "^4.22.0",
+		"vimeo/psalm": "^4.30.0",
 		"phpstan/phpstan": "^1.4.8",
 		"mediawiki/mediawiki-codesniffer": "^46.0.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,15 @@
 	"require-dev": {
 		"vimeo/psalm": "^4.22.0",
 		"phpstan/phpstan": "^1.4.8",
-		"mediawiki/mediawiki-codesniffer": "^39.0.0"
+		"mediawiki/mediawiki-codesniffer": "^46.0.0"
 	},
 	"extra": {
 		"installer-name": "WikibaseRDF"
 	},
 	"config": {
 		"allow-plugins": {
-			"composer/installers": true
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		}
 	],
 	"require": {
-		"php": ">=8.0",
+		"php": ">=8.1",
 		"composer/installers": "^2|^1.0.1"
 	},
 	"require-dev": {

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -10,14 +10,14 @@
 
 Gets the mappings for a specific Wikibase entity.
 
-Route: `/wikibase-rdf/v0/mappings/{entity_id}`
+Route: `/wikibase-rdf/v1/mappings/{entity_id}`
 
 Method: `GET`
 
 Example for retrieving all RDF mappings for entity `Item:Q1`:
 
 ```shell
-curl "http://localhost:8484/rest.php/wikibase-rdf/v0/mappings/Q1"
+curl "http://localhost:8484/rest.php/wikibase-rdf/v1/mappings/Q1"
 ```
 
 ### Request parameters
@@ -91,14 +91,14 @@ The Entity ID format is invalid.
 
 Sets the mappings for a specific Wikibase entity.
 
-Route: `/wikibase-rdf/v0/mappings/{entity_id}`
+Route: `/wikibase-rdf/v1/mappings/{entity_id}`
 
 Method: `POST`
 
 Example for saving all RDF mappings for existing entity `Item:Q1`:
 
 ```shell
-curl -X POST -H 'Content-Type: application/json' "http://localhost:8484/rest.php/wikibase-rdf/v0/mappings/Q1" \
+curl -X POST -H 'Content-Type: application/json' "http://localhost:8484/rest.php/wikibase-rdf/v1/mappings/Q1" \
   -d '{"mappings": [{"predicate": "owl:sameAs", "object": "http://www.w3.org/2000/01/rdf-schema#subClassOf"}, {"predicate": "rdfs:subClassOf", "object": "foo:Bar"}]}'
 ```
 
@@ -112,12 +112,12 @@ curl -X POST -H 'Content-Type: application/json' "http://localhost:8484/rest.php
 
 **Body**
 
-The request body must be a JSON array with each item containing:
+The request body must be a JSON object with a "mappings" key containing an array. Each item in the array should contain:
 
 | key             | type   | description               |
 |-----------------|--------|---------------------------|
-| `[i].predicate` | string | Predicate for mapping `i` |
-| `[i].object`    | string | Object for mapping `i`    |
+| `mappings[i].predicate` | string | Predicate for mapping `i` |
+| `mappings[i].object`    | string | Object for mapping `i`    |
 
 ### Response
 
@@ -199,14 +199,14 @@ Requests containing invalid mappings will respond with the invalid mappings:
 
 Gets the mappings for all Wikibase entities.
 
-Route: `/wikibase-rdf/v0/mappings`
+Route: `/wikibase-rdf/v1/mappings`
 
 Method: `GET`
 
 Example for retrieving all RDF mappings for all entities:
 
 ```shell
-curl "http://localhost:8484/rest.php/wikibase-rdf/v0/mappings"
+curl "http://localhost:8484/rest.php/wikibase-rdf/v1/mappings"
 ```
 
 ### Request parameters

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -99,7 +99,7 @@ Example for saving all RDF mappings for existing entity `Item:Q1`:
 
 ```shell
 curl -X POST -H 'Content-Type: application/json' "http://localhost:8484/rest.php/wikibase-rdf/v0/mappings/Q1" \
-  -d '[{"predicate": "owl:sameAs", "object": "http://www.w3.org/2000/01/rdf-schema#subClassOf"}, {"predicate": "rdfs:subClassOf", "object": "foo:Bar"}]'
+  -d '{"mappings": [{"predicate": "owl:sameAs", "object": "http://www.w3.org/2000/01/rdf-schema#subClassOf"}, {"predicate": "rdfs:subClassOf", "object": "foo:Bar"}]}'
 ```
 
 ### Request parameters

--- a/extension.json
+++ b/extension.json
@@ -2,7 +2,7 @@
 	"name": "Wikibase RDF",
 	"type": "wikibase",
 
-	"version": "1.1.0",
+	"version": "2.0.0",
 
 	"author": [
 		"[https://Professional.Wiki/ Professional.Wiki]",
@@ -16,7 +16,7 @@
 	"descriptionmsg": "wikibase-rdf-description",
 
 	"requires": {
-		"MediaWiki": ">= 1.37.0",
+		"MediaWiki": ">= 1.43.0",
 		"extensions": {
 			"WikibaseRepository": "*"
 		}

--- a/extension.json
+++ b/extension.json
@@ -96,5 +96,9 @@
 		}
 	},
 
+	"ExtensionMessagesFiles": {
+		"WikibaseRdfAlias": "WikibaseRdf.alias.php"
+	},
+
 	"manifest_version": 2
 }

--- a/extension.json
+++ b/extension.json
@@ -46,17 +46,17 @@
 
 	"RestRoutes": [
 		{
-			"path": "/wikibase-rdf/v0/mappings/{entity_id}",
+			"path": "/wikibase-rdf/v1/mappings/{entity_id}",
 			"method": [ "GET" ],
 			"factory": "ProfessionalWiki\\WikibaseRDF\\WikibaseRdfExtension::getMappingsApiFactory"
 		},
 		{
-			"path": "/wikibase-rdf/v0/mappings/{entity_id}",
+			"path": "/wikibase-rdf/v1/mappings/{entity_id}",
 			"method": [ "POST" ],
 			"factory": "ProfessionalWiki\\WikibaseRDF\\WikibaseRdfExtension::saveMappingsApiFactory"
 		},
 		{
-			"path": "/wikibase-rdf/v0/mappings",
+			"path": "/wikibase-rdf/v1/mappings",
 			"method": [ "GET" ],
 			"factory": "ProfessionalWiki\\WikibaseRDF\\WikibaseRdfExtension::getAllMappingsApiFactory"
 		}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -15,6 +15,7 @@
 		<exclude name="MediaWiki.Classes.UnsortedUseStatements.UnsortedUse" />
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
 		<exclude name="MediaWiki.ControlStructures.IfElseStructure.SpaceBeforeElse" />
+		<exclude name="MediaWiki.Usage.StaticClosure.StaticClosure" />
 	</rule>
 
 	<rule ref="Generic.Formatting.NoSpaceAfterCast" />

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,11 @@ parameters:
 			path: src/WikibaseRdfExtension.php
 
 		-
+			message: "#^Parameter \\#1 \\$database of class ProfessionalWiki\\\\WikibaseRDF\\\\Persistence\\\\SqlAllMappingsLookup constructor expects Wikimedia\\\\Rdbms\\\\IDatabase, Wikimedia\\\\Rdbms\\\\IDatabase\\|false given\\.$#"
+			count: 1
+			path: src/WikibaseRdfExtension.php
+
+		-
 			message: "#^Parameter \\#4 \\$availableRights of class Wikibase\\\\Repo\\\\Store\\\\WikiPageEntityStorePermissionChecker constructor expects array\\<string\\>, array given\\.$#"
 			count: 1
 			path: src/WikibaseRdfExtension.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,8 @@ parameters:
 		- ../../tests/phpunit
 		- ../../vendor
 		- ../../extensions/Wikibase
+	bootstrapFiles:
+		- ../../includes/AutoLoader.php
 #	excludePaths:
 #		analyse:
 #			- src/AutomatedValuesFactory.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.7.2@83a0325c0a95c0ab531d6b90c877068b464377b5">
+<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
   <file src="src/MappingListSerializer.php">
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$array</code>
@@ -9,14 +9,14 @@
     </MixedAssignment>
   </file>
   <file src="src/WikibaseRdfExtension.php">
-    <MixedArgument occurrences="1">
-      <code>WikibaseRepo::getLocalEntitySource()-&gt;getRdfNodeNamespacePrefix()</code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>(array)$services-&gt;getMainConfig()-&gt;get( 'AvailableRights' )</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess occurrences="1">
       <code>WikibaseRepo::getSettings()-&gt;getSetting( 'string-limits' )['PT:url']</code>
     </MixedArrayAccess>
+    <PossiblyFalseArgument occurrences="1">
+      <code>MediaWikiServices::getInstance()-&gt;getDBLoadBalancer()-&gt;getConnection( ILoadBalancer::DB_REPLICA )</code>
+    </PossiblyFalseArgument>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
+  <file src="src/EntryPoints/Rest/SaveMappingsApi.php">
+    <MixedArgument occurrences="1">
+      <code>$mappings</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$body</code>
+      <code>$mappings</code>
+    </MixedAssignment>
+  </file>
   <file src="src/MappingListSerializer.php">
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$array</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8,6 +8,13 @@
       <code>$array</code>
     </MixedAssignment>
   </file>
+  <file src="src/Persistence/SqlAllMappingsLookup.php">
+    <InternalMethod occurrences="3">
+      <code>join</code>
+      <code>join</code>
+      <code>join</code>
+    </InternalMethod>
+  </file>
   <file src="src/WikibaseRdfExtension.php">
     <MixedArgumentTypeCoercion occurrences="1">
       <code>(array)$services-&gt;getMainConfig()-&gt;get( 'AvailableRights' )</code>

--- a/resources/ext.wikibase.rdf.js
+++ b/resources/ext.wikibase.rdf.js
@@ -183,7 +183,7 @@ $( function () {
 
 		const api = new mw.Rest();
 		api.post(
-			'/wikibase-rdf/v0/mappings/' + mw.config.get( 'wgTitle' ),
+			'/wikibase-rdf/v1/mappings/' + mw.config.get( 'wgTitle' ),
 			mappings,
 			{ authorization: 'token' }
 		)

--- a/resources/ext.wikibase.rdf.js
+++ b/resources/ext.wikibase.rdf.js
@@ -184,7 +184,7 @@ $( function () {
 		const api = new mw.Rest();
 		api.post(
 			'/wikibase-rdf/v1/mappings/' + mw.config.get( 'wgTitle' ),
-			mappings,
+			{ mappings: mappings },
 			{ authorization: 'token' }
 		)
 			.done( function () {

--- a/src/Application/SaveMappings/SaveMappingsUseCase.php
+++ b/src/Application/SaveMappings/SaveMappingsUseCase.php
@@ -105,7 +105,7 @@ class SaveMappingsUseCase {
 		return array_values(
 			array_filter(
 				$mappings,
-				fn( array $mapping ) => !$this->mappingIsValid( $mapping[self::PREDICATE_KEY], $mapping[self::OBJECT_KEY] )
+				fn ( array $mapping ) => !$this->mappingIsValid( $mapping[self::PREDICATE_KEY], $mapping[self::OBJECT_KEY] )
 			)
 		);
 	}

--- a/src/DataAccess/PageContentFetcher.php
+++ b/src/DataAccess/PageContentFetcher.php
@@ -19,8 +19,7 @@ class PageContentFetcher {
 	public function getPageContent( string $pageTitle ): ?\Content {
 		try {
 			$title = $this->titleParser->parseTitle( $pageTitle );
-		}
-		catch ( \MalformedTitleException $e ) {
+		} catch ( \MalformedTitleException $e ) {
 			return null;
 		}
 

--- a/src/DataAccess/PredicatesDeserializer.php
+++ b/src/DataAccess/PredicatesDeserializer.php
@@ -22,7 +22,7 @@ class PredicatesDeserializer {
 		return new PredicateList(
 			array_values(
 				array_map(
-					static fn ( string $predicate ) => new Predicate( $predicate ),
+					fn ( string $predicate ) => new Predicate( $predicate ),
 					$this->validator->getValidPredicates()
 				)
 			)

--- a/src/DataAccess/PredicatesDeserializer.php
+++ b/src/DataAccess/PredicatesDeserializer.php
@@ -22,7 +22,7 @@ class PredicatesDeserializer {
 		return new PredicateList(
 			array_values(
 				array_map(
-					fn( string $predicate ) => new Predicate( $predicate ),
+					static fn ( string $predicate ) => new Predicate( $predicate ),
 					$this->validator->getValidPredicates()
 				)
 			)

--- a/src/DataAccess/PredicatesTextValidator.php
+++ b/src/DataAccess/PredicatesTextValidator.php
@@ -36,7 +36,7 @@ class PredicatesTextValidator {
 	private function normalizeLines( string $predicatesText ): array {
 		return array_filter(
 			array_map(
-				fn( string $predicate ) => trim( $predicate ),
+				static fn ( string $predicate ) => trim( $predicate ),
 				explode( "\n", $predicatesText )
 			)
 		);

--- a/src/DataAccess/PredicatesTextValidator.php
+++ b/src/DataAccess/PredicatesTextValidator.php
@@ -36,7 +36,7 @@ class PredicatesTextValidator {
 	private function normalizeLines( string $predicatesText ): array {
 		return array_filter(
 			array_map(
-				static fn ( string $predicate ) => trim( $predicate ),
+				fn ( string $predicate ) => trim( $predicate ),
 				explode( "\n", $predicatesText )
 			)
 		);

--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -94,7 +94,7 @@ class MediaWikiHooks {
 	}
 
 	private static function newEntityRdfBuilderFactoryFunction( callable $factoryFunction ): callable {
-		return static fn (
+		return fn (
 			int $flavorFlags,
 			RdfVocabulary $vocabulary,
 			RdfWriter $writer
@@ -126,7 +126,7 @@ class MediaWikiHooks {
 		$imploded = implode(
 			', ',
 			array_map(
-				static fn ( string $predicate ) => '"' . $predicate . '"',
+				fn ( string $predicate ) => '"' . $predicate . '"',
 				$invalidPredicates
 			)
 		);

--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -58,8 +58,7 @@ class MediaWikiHooks {
 
 		try {
 			return WikibaseRepo::getEntityIdParser()->parse( $title->getText() );
-		}
-		catch ( EntityIdParsingException ) {
+		} catch ( EntityIdParsingException ) {
 			return null;
 		}
 	}
@@ -95,7 +94,7 @@ class MediaWikiHooks {
 	}
 
 	private static function newEntityRdfBuilderFactoryFunction( callable $factoryFunction ): callable {
-		return fn(
+		return static fn (
 			int $flavorFlags,
 			RdfVocabulary $vocabulary,
 			RdfWriter $writer
@@ -127,7 +126,7 @@ class MediaWikiHooks {
 		$imploded = implode(
 			', ',
 			array_map(
-				fn( string $predicate ) => '"' . $predicate . '"',
+				static fn ( string $predicate ) => '"' . $predicate . '"',
 				$invalidPredicates
 			)
 		);
@@ -139,7 +138,7 @@ class MediaWikiHooks {
 	public static function onAlternateEdit( EditPage $editPage ): void {
 		if ( WikibaseRdfExtension::getInstance()->isConfigTitle( $editPage->getTitle() ) ) {
 			$editPage->suppressIntro = true;
-			$editPage->editFormTextBeforeContent = wfMessage( 'wikibase-rdf-config-intro' );
+			$editPage->editFormTextBeforeContent = wfMessage( 'wikibase-rdf-config-intro' )->parse();
 		}
 	}
 

--- a/src/EntryPoints/MediaWikiHooks.php
+++ b/src/EntryPoints/MediaWikiHooks.php
@@ -4,18 +4,17 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\EntryPoints;
 
-use EditPage;
+use MediaWiki\EditPage\EditPage;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRoleRegistry;
-use OutputPage;
-use ParserOutput;
-use ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesDeserializer;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesTextValidator;
 use ProfessionalWiki\WikibaseRDF\Presentation\RDF\MultiEntityRdfBuilder;
 use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
-use Title;
-use User;
 use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\EntityIdParsingException;
 use Wikibase\Lib\EntityTypeDefinitions;

--- a/src/EntryPoints/Rest/SaveMappingsApi.php
+++ b/src/EntryPoints/Rest/SaveMappingsApi.php
@@ -16,7 +16,13 @@ class SaveMappingsApi extends SimpleHandler {
 	public function run( string $entityId ): Response {
 		$presenter = WikibaseRdfExtension::getInstance()->newRestSaveMappingsPresenter( $this->getResponseFactory() );
 		$useCase = WikibaseRdfExtension::getInstance()->newSaveMappingsUseCase( $presenter, $this->getUser() );
-		$useCase->saveMappings( $entityId, (array)$this->getValidatedBody() );
+
+		$body = $this->getValidatedBody();
+		$mappings = ( is_array( $body ) && isset( $body['mappings'] ) )
+			? $body['mappings']
+			: [];
+
+		$useCase->saveMappings( $entityId, $mappings );
 
 		return $presenter->getResponse();
 	}
@@ -35,6 +41,20 @@ class SaveMappingsApi extends SimpleHandler {
 				self::PARAM_SOURCE => 'path',
 				ParamValidator::PARAM_TYPE => 'string',
 				ParamValidator::PARAM_REQUIRED => true,
+			],
+		];
+	}
+
+	/**
+	 * @inheritDoc
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getBodyParamSettings(): array {
+		return [
+			'mappings' => [
+				self::PARAM_SOURCE => 'body',
+				ParamValidator::PARAM_TYPE => 'array',
+				ParamValidator::PARAM_REQUIRED => true
 			],
 		];
 	}

--- a/src/EntryPoints/Rest/SaveMappingsApi.php
+++ b/src/EntryPoints/Rest/SaveMappingsApi.php
@@ -17,10 +17,8 @@ class SaveMappingsApi extends SimpleHandler {
 		$presenter = WikibaseRdfExtension::getInstance()->newRestSaveMappingsPresenter( $this->getResponseFactory() );
 		$useCase = WikibaseRdfExtension::getInstance()->newSaveMappingsUseCase( $presenter, $this->getUser() );
 
-		$body = $this->getValidatedBody();
-		$mappings = ( is_array( $body ) && isset( $body['mappings'] ) )
-			? $body['mappings']
-			: [];
+		$body = is_array( $this->getValidatedBody() ) ? $this->getValidatedBody() : [];
+		$mappings = isset( $body['mappings'] ) ? (array)$body['mappings'] : [];
 
 		$useCase->saveMappings( $entityId, $mappings );
 

--- a/src/EntryPoints/Rest/SaveMappingsApi.php
+++ b/src/EntryPoints/Rest/SaveMappingsApi.php
@@ -4,14 +4,11 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\EntryPoints\Rest;
 
-use MediaWiki\Rest\HttpException;
+use MediaWiki\Context\RequestContext;
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
-use MediaWiki\Rest\Validator\BodyValidator;
-use MediaWiki\Rest\Validator\JsonBodyValidator;
+use MediaWiki\User\User;
 use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
-use RequestContext;
-use User;
 use Wikimedia\ParamValidator\ParamValidator;
 
 class SaveMappingsApi extends SimpleHandler {
@@ -40,21 +37,6 @@ class SaveMappingsApi extends SimpleHandler {
 				ParamValidator::PARAM_REQUIRED => true,
 			],
 		];
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function getBodyValidator( $contentType ): BodyValidator {
-		if ( $contentType !== 'application/json' ) {
-			throw new HttpException(
-				"Unsupported Content-Type",
-				415,
-				[ 'content_type' => $contentType ]
-			);
-		}
-
-		return new JsonBodyValidator( [] );
 	}
 
 }

--- a/src/EntryPoints/Rest/SaveMappingsApi.php
+++ b/src/EntryPoints/Rest/SaveMappingsApi.php
@@ -17,8 +17,10 @@ class SaveMappingsApi extends SimpleHandler {
 		$presenter = WikibaseRdfExtension::getInstance()->newRestSaveMappingsPresenter( $this->getResponseFactory() );
 		$useCase = WikibaseRdfExtension::getInstance()->newSaveMappingsUseCase( $presenter, $this->getUser() );
 
-		$body = is_array( $this->getValidatedBody() ) ? $this->getValidatedBody() : [];
-		$mappings = isset( $body['mappings'] ) ? (array)$body['mappings'] : [];
+		$body = $this->getValidatedBody();
+		$mappings = ( is_array( $body ) && isset( $body['mappings'] ) )
+			? $body['mappings']
+			: [];
 
 		$useCase->saveMappings( $entityId, $mappings );
 

--- a/src/MappingListSerializer.php
+++ b/src/MappingListSerializer.php
@@ -68,7 +68,7 @@ class MappingListSerializer {
 	 */
 	public function mappingListToArray( MappingList $mappings ): array {
 		return array_map(
-			static fn ( Mapping $mapping ) => [
+			fn ( Mapping $mapping ) => [
 				self::PREDICATE_KEY => $mapping->predicate,
 				self::OBJECT_KEY => $mapping->object
 			],

--- a/src/MappingListSerializer.php
+++ b/src/MappingListSerializer.php
@@ -29,7 +29,7 @@ class MappingListSerializer {
 	public function mappingListFromArray( array $mappings ): MappingList {
 		return new MappingList(
 			array_map(
-				fn( array $mapping ) => $this->mappingFromArray( $mapping ),
+				fn ( array $mapping ) => $this->mappingFromArray( $mapping ),
 				$mappings
 			)
 		);
@@ -68,7 +68,7 @@ class MappingListSerializer {
 	 */
 	public function mappingListToArray( MappingList $mappings ): array {
 		return array_map(
-			fn( Mapping $mapping ) => [
+			static fn ( Mapping $mapping ) => [
 				self::PREDICATE_KEY => $mapping->predicate,
 				self::OBJECT_KEY => $mapping->object
 			],

--- a/src/Persistence/EntityContentRepository.php
+++ b/src/Persistence/EntityContentRepository.php
@@ -4,8 +4,8 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\Persistence;
 
-use Content;
 use Exception;
+use MediaWiki\Content\Content;
 use Wikibase\DataModel\Entity\EntityId;
 
 /**

--- a/src/Persistence/SlotEntityContentRepository.php
+++ b/src/Persistence/SlotEntityContentRepository.php
@@ -38,8 +38,7 @@ class SlotEntityContentRepository implements EntityContentRepository {
 
 		try {
 			return $revision?->getSlot( $this->slotName, RevisionRecord::FOR_PUBLIC, $this->authority )?->getContent();
-		}
-		catch ( RevisionAccessException ) {
+		} catch ( RevisionAccessException ) {
 			return null;
 		}
 	}
@@ -47,8 +46,7 @@ class SlotEntityContentRepository implements EntityContentRepository {
 	private function getWikiPage( EntityId $entityId ): ?WikiPage {
 		try {
 			$title = $this->entityTitleLookup->getTitleForId( $entityId );
-		}
-		catch ( Exception ) {
+		} catch ( Exception ) {
 			return null;
 		}
 

--- a/src/Persistence/SlotEntityContentRepository.php
+++ b/src/Persistence/SlotEntityContentRepository.php
@@ -4,10 +4,9 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\Persistence;
 
-use CommentStoreComment;
-use Content;
 use Exception;
-use MediaWiki\MediaWikiServices;
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Content\Content;
 use MediaWiki\Page\WikiPageFactory;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Revision\RevisionAccessException;

--- a/src/Persistence/SqlAllMappingsLookup.php
+++ b/src/Persistence/SqlAllMappingsLookup.php
@@ -35,9 +35,11 @@ class SqlAllMappingsLookup implements AllMappingsLookup {
 				'p.page_title',
 			] )
 			->from( 'text', 't' )
-			->join( 'slots', 's', 's.slot_content_id=t.old_id' )
-			->join( 'slot_roles', 'r', 'r.role_id=s.slot_role_id' )
-			->join( 'page', 'p', 'p.page_latest=s.slot_revision_id' )
+			->joinConds( [
+				'slots' => [ 'INNER JOIN', 's.slot_content_id=t.old_id' ],
+				'slot_roles' => [ 'INNER JOIN', 'r.role_id=s.slot_role_id' ],
+				'page' => [ 'INNER JOIN', 'p.page_latest=s.slot_revision_id' ]
+			] )
 			->where( [ 'r.role_name' => $this->slotName ] )
 			->caller( __METHOD__ )
 			->fetchResultSet();

--- a/src/Persistence/SqlAllMappingsLookup.php
+++ b/src/Persistence/SqlAllMappingsLookup.php
@@ -35,11 +35,9 @@ class SqlAllMappingsLookup implements AllMappingsLookup {
 				'p.page_title',
 			] )
 			->from( 'text', 't' )
-			->joinConds( [
-				'slots' => [ 'INNER JOIN', 's.slot_content_id=t.old_id' ],
-				'slot_roles' => [ 'INNER JOIN', 'r.role_id=s.slot_role_id' ],
-				'page' => [ 'INNER JOIN', 'p.page_latest=s.slot_revision_id' ]
-			] )
+			->join( 'slots', 's', 's.slot_content_id=t.old_id' )
+			->join( 'slot_roles', 'r', 'r.role_id=s.slot_role_id' )
+			->join( 'page', 'p', 'p.page_latest=s.slot_revision_id' )
 			->where( [ 'r.role_name' => $this->slotName ] )
 			->caller( __METHOD__ )
 			->fetchResultSet();

--- a/src/Presentation/HtmlPredicatesPresenter.php
+++ b/src/Presentation/HtmlPredicatesPresenter.php
@@ -65,7 +65,7 @@ class HtmlPredicatesPresenter implements PredicatesPresenter {
 	 */
 	private function createWikiListItems(): array {
 		return array_map(
-			fn( Predicate $predicate ) => Html::element( 'li', [], $predicate->predicate ),
+			static fn ( Predicate $predicate ) => Html::element( 'li', [], $predicate->predicate ),
 			$this->wikiPredicates->asArray()
 		);
 	}

--- a/src/Presentation/HtmlPredicatesPresenter.php
+++ b/src/Presentation/HtmlPredicatesPresenter.php
@@ -65,7 +65,7 @@ class HtmlPredicatesPresenter implements PredicatesPresenter {
 	 */
 	private function createWikiListItems(): array {
 		return array_map(
-			static fn ( Predicate $predicate ) => Html::element( 'li', [], $predicate->predicate ),
+			fn ( Predicate $predicate ) => Html::element( 'li', [], $predicate->predicate ),
 			$this->wikiPredicates->asArray()
 		);
 	}

--- a/src/Presentation/RDF/MappingRdfBuilder.php
+++ b/src/Presentation/RDF/MappingRdfBuilder.php
@@ -85,7 +85,7 @@ class MappingRdfBuilder implements EntityRdfBuilder {
 
 	private function addPropertyMapping( Mapping $mapping, EntityId $entityId ): void {
 		$this->writer
-			->about( $this->propertyMappingPrefixBuilder->getPrefix(), $entityId->getLocalPart() )
+			->about( $this->propertyMappingPrefixBuilder->getPrefix(), $entityId->getSerialization() )
 			->a( 'owl', 'ObjectProperty' )
 			->say( $mapping->getPredicateBase(), $mapping->getPredicateLocal() )
 			->is( $mapping->object );

--- a/src/Presentation/RestSaveMappingsPresenter.php
+++ b/src/Presentation/RestSaveMappingsPresenter.php
@@ -7,7 +7,6 @@ namespace ProfessionalWiki\WikibaseRDF\Presentation;
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\ResponseFactory;
 use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsPresenter;
-use Throwable;
 use Wikimedia\Message\MessageValue;
 
 class RestSaveMappingsPresenter implements SaveMappingsPresenter {

--- a/src/SpecialMappingPredicates.php
+++ b/src/SpecialMappingPredicates.php
@@ -4,7 +4,9 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF;
 
-use SpecialPage;
+use MediaWiki\Message\Message;
+use MediaWiki\SpecialPage\SpecialPage;
+use MediaWiki\Title\Title;
 
 class SpecialMappingPredicates extends SpecialPage {
 
@@ -15,9 +17,9 @@ class SpecialMappingPredicates extends SpecialPage {
 	public function execute( $subPage ): void {
 		parent::execute( $subPage );
 
-		$title = \Title::newFromText( 'MediaWiki:MappingPredicates' );
+		$title = Title::newFromText( 'MediaWiki:MappingPredicates' );
 
-		if ( $title instanceof \Title ) {
+		if ( $title instanceof Title ) {
 			$this->getOutput()->redirect( $title->getFullURL() );
 		}
 	}
@@ -26,8 +28,8 @@ class SpecialMappingPredicates extends SpecialPage {
 		return 'wikibase';
 	}
 
-	public function getDescription(): string {
-		return $this->msg( 'special-mapping-predicates' )->escaped();
+	public function getDescription(): Message {
+		return $this->msg( 'special-mapping-predicates' );
 	}
 
 }

--- a/src/WikibaseRdfExtension.php
+++ b/src/WikibaseRdfExtension.php
@@ -4,9 +4,12 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF;
 
+use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Permissions\Authority;
 use MediaWiki\Rest\ResponseFactory;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use ProfessionalWiki\WikibaseRDF\Application\AllMappingsLookup;
 use ProfessionalWiki\WikibaseRDF\Application\EntityMappingsAuthorizer;
 use ProfessionalWiki\WikibaseRDF\Application\MappingRepository;
@@ -16,7 +19,6 @@ use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsPresenter;
 use ProfessionalWiki\WikibaseRDF\Application\SaveMappings\SaveMappingsUseCase;
 use ProfessionalWiki\WikibaseRDF\DataAccess\CombiningMappingPredicatesLookup;
 use ProfessionalWiki\WikibaseRDF\DataAccess\LocalSettingsMappingPredicatesLookup;
-use ProfessionalWiki\WikibaseRDF\DataAccess\MappingPredicatesLookup;
 use ProfessionalWiki\WikibaseRDF\DataAccess\PageContentFetcher;
 use ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesDeserializer;
 use ProfessionalWiki\WikibaseRDF\DataAccess\PredicatesTextValidator;
@@ -33,9 +35,6 @@ use ProfessionalWiki\WikibaseRDF\EntryPoints\Rest\SaveMappingsApi;
 use ProfessionalWiki\WikibaseRDF\Presentation\RDF\PropertyMappingPrefixBuilder;
 use ProfessionalWiki\WikibaseRDF\Presentation\RestSaveMappingsPresenter;
 use ProfessionalWiki\WikibaseRDF\Presentation\HtmlMappingsPresenter;
-use RequestContext;
-use Title;
-use User;
 use ValueValidators\ValueValidator;
 use Wikibase\DataModel\Entity\BasicEntityIdParser;
 use Wikibase\DataModel\Entity\EntityIdParser;
@@ -141,7 +140,7 @@ class WikibaseRdfExtension {
 
 	private function newAllMappingsLookup(): AllMappingsLookup {
 		return new SqlAllMappingsLookup(
-			MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnectionRef( ILoadBalancer::DB_REPLICA ),
+			MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( ILoadBalancer::DB_REPLICA ),
 			self::SLOT_NAME,
 			$this->newEntityIdParser(),
 			$this->newMappingListSerializer()

--- a/tests/DataAccess/CombiningMappingPredicatesLookupTest.php
+++ b/tests/DataAccess/CombiningMappingPredicatesLookupTest.php
@@ -43,7 +43,7 @@ class CombiningMappingPredicatesLookupTest extends WikibaseRdfIntegrationTest {
 	}
 
 	public function testValidLocalSettingsAndEmptyPageConfigGetsCombined(): void {
-		$this->setAllowedPredicates( [ 'owl:sameAs','owl:SymmetricProperty' ] );
+		$this->setAllowedPredicates( [ 'owl:sameAs', 'owl:SymmetricProperty' ] );
 		$this->createConfigPage( '' );
 
 		$lookup = WikibaseRdfExtension::getInstance()->newMappingPredicatesLookup();
@@ -58,7 +58,7 @@ class CombiningMappingPredicatesLookupTest extends WikibaseRdfIntegrationTest {
 	}
 
 	public function testInvalidLocalSettingsAreIgnored(): void {
-		$this->setAllowedPredicates( [ 'owl:sameAs','fooBar' ] );
+		$this->setAllowedPredicates( [ 'owl:sameAs', 'fooBar' ] );
 		$this->createConfigPage( '' );
 
 		$lookup = WikibaseRdfExtension::getInstance()->newMappingPredicatesLookup();
@@ -72,7 +72,7 @@ class CombiningMappingPredicatesLookupTest extends WikibaseRdfIntegrationTest {
 	}
 
 	public function testValidLocalSettingsAndValidPageConfigGetsCombined(): void {
-		$this->setAllowedPredicates( [ 'owl:sameAs','owl:SymmetricProperty' ] );
+		$this->setAllowedPredicates( [ 'owl:sameAs', 'owl:SymmetricProperty' ] );
 		$this->createConfigPage( "foo:bar\nbar:Baz" );
 
 		$lookup = WikibaseRdfExtension::getInstance()->newMappingPredicatesLookup();

--- a/tests/DataAccess/CombiningMappingPredicatesLookupTest.php
+++ b/tests/DataAccess/CombiningMappingPredicatesLookupTest.php
@@ -11,6 +11,7 @@ use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
 
 /**
  * @covers \ProfessionalWiki\WikibaseRDF\DataAccess\CombiningMappingPredicatesLookup
+ * @group Database
  */
 class CombiningMappingPredicatesLookupTest extends WikibaseRdfIntegrationTest {
 

--- a/tests/DataAccess/WikiMappingPredicatesLookupTest.php
+++ b/tests/DataAccess/WikiMappingPredicatesLookupTest.php
@@ -16,6 +16,7 @@ use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
 
 /**
  * @covers \ProfessionalWiki\WikibaseRDF\DataAccess\WikiMappingPredicatesLookup
+ * @group Database
  */
 class WikiMappingPredicatesLookupTest extends WikibaseRdfIntegrationTest {
 

--- a/tests/EntryPoints/Rest/GetMappingsApiTest.php
+++ b/tests/EntryPoints/Rest/GetMappingsApiTest.php
@@ -86,9 +86,7 @@ class GetMappingsApiTest extends WikibaseRdfIntegrationTest {
 
 		$this->assertStringContainsString(
 			'wikibase-rdf-entity-id-invalid',
-			$data['messageTranslations'][''] ??
-				// MediaWiki 1.39+
-				$data['messageTranslations']['qqx']
+			$data['messageTranslations']['qqx']
 		);
 	}
 

--- a/tests/EntryPoints/Rest/GetMappingsApiTest.php
+++ b/tests/EntryPoints/Rest/GetMappingsApiTest.php
@@ -15,6 +15,7 @@ use Wikibase\DataModel\Entity\ItemId;
 /**
  * @covers \ProfessionalWiki\WikibaseRDF\EntryPoints\Rest\GetMappingsApi
  * @covers \ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension
+ * @group Database
  */
 class GetMappingsApiTest extends WikibaseRdfIntegrationTest {
 	use HandlerTestTrait;

--- a/tests/EntryPoints/Rest/SaveMappingsApiTest.php
+++ b/tests/EntryPoints/Rest/SaveMappingsApiTest.php
@@ -4,15 +4,14 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\Tests\EntryPoints\Rest;
 
-use MediaWiki\Permissions\Authority;
+use MediaWiki\Context\RequestContext;
 use MediaWiki\Rest\LocalizedHttpException;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Rest\ResponseInterface;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use MediaWiki\User\User;
 use ProfessionalWiki\WikibaseRDF\Tests\WikibaseRdfIntegrationTest;
 use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
-use RequestContext;
-use User;
 use Wikibase\DataModel\Entity\ItemId;
 
 /**
@@ -67,15 +66,12 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 
 		$this->assertStringContainsString(
 			'wikibase-rdf-save-mappings-invalid-mappings',
-			$data['messageTranslations'][''] ??
-				// MediaWiki 1.39+
-				$data['messageTranslations']['qqx']
+			$data['messageTranslations']['qqx']
 		);
 	}
 
 	/**
 	 * This result is the same as testJsonIsAnEmptyList() because it's decoded as an empty list.
-	 * @see JsonBodyValidator::validateBody()
 	 */
 	public function testJsonIsAnEmptyObject(): void {
 		$response = $this->doSaveMappingsRequest( 'Q1', '{}' );
@@ -108,9 +104,7 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 
 		$this->assertStringContainsString(
 			'wikibase-rdf-save-mappings-invalid-mappings',
-			$data['messageTranslations'][''] ??
-				// MediaWiki 1.39+
-				$data['messageTranslations']['qqx']
+			$data['messageTranslations']['qqx']
 		);
 	}
 
@@ -133,9 +127,7 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 
 		$this->assertStringContainsString(
 			'wikibase-rdf-save-mappings-invalid-mappings',
-			$data['messageTranslations'][''] ??
-				// MediaWiki 1.39+
-				$data['messageTranslations']['qqx']
+			$data['messageTranslations']['qqx']
 		);
 	}
 
@@ -158,9 +150,7 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 
 		$this->assertStringContainsString(
 			'wikibase-rdf-save-mappings-invalid-mappings',
-			$data['messageTranslations'][''] ??
-				// MediaWiki 1.39+
-				$data['messageTranslations']['qqx']
+			$data['messageTranslations']['qqx']
 		);
 	}
 
@@ -183,9 +173,7 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 
 		$this->assertStringContainsString(
 			'wikibase-rdf-save-mappings-invalid-mappings',
-			$data['messageTranslations'][''] ??
-				// MediaWiki 1.39+
-				$data['messageTranslations']['qqx']
+			$data['messageTranslations']['qqx']
 		);
 	}
 
@@ -208,9 +196,7 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 
 		$this->assertStringContainsString(
 			'wikibase-rdf-save-mappings-invalid-mappings',
-			$data['messageTranslations'][''] ??
-				// MediaWiki 1.39+
-				$data['messageTranslations']['qqx']
+			$data['messageTranslations']['qqx']
 		);
 	}
 
@@ -233,9 +219,7 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 
 		$this->assertStringContainsString(
 			'wikibase-rdf-save-mappings-invalid-mappings',
-			$data['messageTranslations'][''] ??
-				// MediaWiki 1.39+
-				$data['messageTranslations']['qqx']
+			$data['messageTranslations']['qqx']
 		);
 	}
 
@@ -258,9 +242,7 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 
 		$this->assertStringContainsString(
 			'wikibase-rdf-save-mappings-invalid-mappings',
-			$data['messageTranslations'][''] ??
-				// MediaWiki 1.39+
-				$data['messageTranslations']['qqx']
+			$data['messageTranslations']['qqx']
 		);
 	}
 
@@ -283,9 +265,7 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 
 		$this->assertStringContainsString(
 			'wikibase-rdf-save-mappings-invalid-mappings',
-			$data['messageTranslations'][''] ??
-				// MediaWiki 1.39+
-				$data['messageTranslations']['qqx']
+			$data['messageTranslations']['qqx']
 		);
 	}
 
@@ -308,9 +288,7 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 
 		$this->assertStringContainsString(
 			'wikibase-rdf-save-mappings-invalid-mappings',
-			$data['messageTranslations'][''] ??
-				// MediaWiki 1.39+
-				$data['messageTranslations']['qqx']
+			$data['messageTranslations']['qqx']
 		);
 	}
 
@@ -325,9 +303,7 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 
 		$this->assertStringContainsString(
 			'wikibase-rdf-entity-id-invalid',
-			$data['messageTranslations'][''] ??
-				// MediaWiki 1.39+
-				$data['messageTranslations']['qqx']
+			$data['messageTranslations']['qqx']
 		);
 	}
 

--- a/tests/EntryPoints/Rest/SaveMappingsApiTest.php
+++ b/tests/EntryPoints/Rest/SaveMappingsApiTest.php
@@ -462,7 +462,7 @@ class SaveMappingsApiTest extends WikibaseRdfIntegrationTest {
 				'method' => 'POST',
 				'pathParams' => [ 'entity_id' => $entityId ],
 				'headers' => [ 'Content-Type' => 'application/json' ],
-				'bodyContents' => $body
+				'bodyContents' => '{"mappings": ' . $body . '}'
 			] )
 		);
 	}

--- a/tests/Persistence/SlotEntityContentRepositoryTest.php
+++ b/tests/Persistence/SlotEntityContentRepositoryTest.php
@@ -5,12 +5,13 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\WikibaseRDF\Tests\Persistence;
 
 use Exception;
+use MediaWiki\Content\JsonContent;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionLookup;
+use MediaWiki\Title\Title;
 use ProfessionalWiki\WikibaseRDF\Persistence\SlotEntityContentRepository;
 use ProfessionalWiki\WikibaseRDF\Tests\WikibaseRdfIntegrationTest;
 use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
-use Title;
 use Wikibase\DataModel\Entity\ItemId;
 
 /**
@@ -48,13 +49,13 @@ class SlotEntityContentRepositoryTest extends WikibaseRdfIntegrationTest {
 
 		$repo->setContent(
 			new ItemId( 'Q100' ),
-			new \JsonContent( '{ "foo": 42 }' )
+			new JsonContent( '{ "foo": 42 }' )
 		);
 
 		$this->assertEquals(
-			new \JsonContent(
+			new JsonContent(
 '{
-    "foo": 42
+	"foo": 42
 }'
 			),
 			$repo->getContent( new ItemId( 'Q100' ) )
@@ -66,7 +67,7 @@ class SlotEntityContentRepositoryTest extends WikibaseRdfIntegrationTest {
 
 		$this->newRepo()->setContent(
 			new ItemId( 'Q404' ),
-			new \JsonContent( '{ "foo": 42 }' )
+			new JsonContent( '{ "foo": 42 }' )
 		);
 	}
 
@@ -75,19 +76,19 @@ class SlotEntityContentRepositoryTest extends WikibaseRdfIntegrationTest {
 
 		$repo->setContent(
 			new ItemId( 'Q100' ),
-			new \JsonContent( '{ "foo": 42, "bar": 9001, "baz": 1337 }' )
+			new JsonContent( '{ "foo": 42, "bar": 9001, "baz": 1337 }' )
 		);
 
 		$repo->setContent(
 			new ItemId( 'Q100' ),
-			new \JsonContent( '{ "foo": 1, "bah": 2 }' )
+			new JsonContent( '{ "foo": 1, "bah": 2 }' )
 		);
 
 		$this->assertEquals(
-			new \JsonContent(
-				'{
-    "foo": 1,
-    "bah": 2
+			new JsonContent(
+'{
+	"foo": 1,
+	"bah": 2
 }'
 			),
 			$repo->getContent( new ItemId( 'Q100' ) )
@@ -103,38 +104,38 @@ class SlotEntityContentRepositoryTest extends WikibaseRdfIntegrationTest {
 
 		$repo->setContent(
 			new ItemId( 'Q100' ),
-			new \JsonContent( '{ "foo": 42 }' )
+			new JsonContent( '{ "foo": 42 }' )
 		);
 		$firstRevisionId = $this->getRevisionLookup()->getRevisionByTitle( Title::newFromText( 'Item:Q100' ) )->getId();
 
 		$repo->setContent(
 			new ItemId( 'Q100' ),
-			new \JsonContent( '{ "foo": 84 }' )
+			new JsonContent( '{ "foo": 84 }' )
 		);
 		$latestRevisionId = $this->getRevisionLookup()->getRevisionByTitle( Title::newFromText( 'Item:Q100' ) )->getId();
 
 		$this->assertEquals(
-			new \JsonContent(
-				'{
-    "foo": 42
+			new JsonContent(
+'{
+	"foo": 42
 }'
 			),
 			$repo->getContent( new ItemId( 'Q100' ), $firstRevisionId )
 		);
 
 		$this->assertEquals(
-			new \JsonContent(
-				'{
-    "foo": 84
+			new JsonContent(
+'{
+	"foo": 84
 }'
 			),
 			$repo->getContent( new ItemId( 'Q100' ), $latestRevisionId )
 		);
 
 		$this->assertEquals(
-			new \JsonContent(
-				'{
-    "foo": 84
+			new JsonContent(
+'{
+	"foo": 84
 }'
 			),
 			$repo->getContent( new ItemId( 'Q100' ) )

--- a/tests/Persistence/SqlAllMappingsLookupPerformanceTest.php
+++ b/tests/Persistence/SqlAllMappingsLookupPerformanceTest.php
@@ -75,7 +75,7 @@ class SqlAllMappingsLookupPerformanceTest extends WikibaseRdfIntegrationTest {
 		$this->assertSame(
 			$items * $mappings,
 			array_sum(
-				array_map( static fn ( MappingListAndId $mapping ) => count( $mapping->mappingList->asArray() ), $allMappings )
+				array_map( fn ( MappingListAndId $mapping ) => count( $mapping->mappingList->asArray() ), $allMappings )
 			)
 		);
 		$this->assertLessThan( $expectedTime, $took );
@@ -84,7 +84,7 @@ class SqlAllMappingsLookupPerformanceTest extends WikibaseRdfIntegrationTest {
 	private function createBulkMappings( int $count, int $revision ): MappingList {
 		return new MappingList(
 			array_map(
-				static fn ( $i ) => new Mapping( 'foo:bar', "http://example.com/$i-$revision" ),
+				fn ( $i ) => new Mapping( 'foo:bar', "http://example.com/$i-$revision" ),
 				range( 0, $count - 1 )
 			)
 		);

--- a/tests/Persistence/SqlAllMappingsLookupPerformanceTest.php
+++ b/tests/Persistence/SqlAllMappingsLookupPerformanceTest.php
@@ -75,7 +75,7 @@ class SqlAllMappingsLookupPerformanceTest extends WikibaseRdfIntegrationTest {
 		$this->assertSame(
 			$items * $mappings,
 			array_sum(
-				array_map( fn( MappingListAndId $mapping ) => count( $mapping->mappingList->asArray() ), $allMappings )
+				array_map( static fn ( MappingListAndId $mapping ) => count( $mapping->mappingList->asArray() ), $allMappings )
 			)
 		);
 		$this->assertLessThan( $expectedTime, $took );
@@ -84,7 +84,7 @@ class SqlAllMappingsLookupPerformanceTest extends WikibaseRdfIntegrationTest {
 	private function createBulkMappings( int $count, int $revision ): MappingList {
 		return new MappingList(
 			array_map(
-				fn( $i ) => new Mapping( 'foo:bar', "http://example.com/$i-$revision" ),
+				static fn ( $i ) => new Mapping( 'foo:bar', "http://example.com/$i-$revision" ),
 				range( 0, $count - 1 )
 			)
 		);

--- a/tests/Persistence/SqlAllMappingsLookupPerformanceTest.php
+++ b/tests/Persistence/SqlAllMappingsLookupPerformanceTest.php
@@ -29,7 +29,7 @@ class SqlAllMappingsLookupPerformanceTest extends WikibaseRdfIntegrationTest {
 
 	private function newSqlAllMappingsLookup(): SqlAllMappingsLookup {
 		return new SqlAllMappingsLookup(
-			$this->db,
+			$this->getDb(),
 			WikibaseRdfExtension::SLOT_NAME,
 			WikibaseRepo::getEntityIdParser(),
 			WikibaseRdfExtension::getInstance()->newMappingListSerializer()

--- a/tests/Persistence/SqlAllMappingsLookupTest.php
+++ b/tests/Persistence/SqlAllMappingsLookupTest.php
@@ -12,7 +12,6 @@ use ProfessionalWiki\WikibaseRDF\Tests\WikibaseRdfIntegrationTest;
 use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\NumericPropertyId;
-use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\Repo\WikibaseRepo;
 
 /**
@@ -29,18 +28,11 @@ class SqlAllMappingsLookupTest extends WikibaseRdfIntegrationTest {
 
 	private function newSqlAllMappingsLookup(): SqlAllMappingsLookup {
 		return new SqlAllMappingsLookup(
-			$this->db,
+			$this->getDb(),
 			WikibaseRdfExtension::SLOT_NAME,
 			WikibaseRepo::getEntityIdParser(),
 			WikibaseRdfExtension::getInstance()->newMappingListSerializer()
 		);
-	}
-
-	private function createPropertyId( string $id ): PropertyId {
-		if ( class_exists( PropertyId::class ) ) {
-			return new PropertyId( $id );
-		}
-		return new NumericPropertyId( $id );
 	}
 
 	private function saveTestMappings(): void {
@@ -59,15 +51,15 @@ class SqlAllMappingsLookupTest extends WikibaseRdfIntegrationTest {
 				new Mapping( 'foo:baz', 'https://example.com/#baz1' )
 			] )
 		);
-		$this->createProperty( $this->createPropertyId( 'P99001' ) );
+		$this->createProperty( new NumericPropertyId( 'P99001' ) );
 		$this->createPropertyWithMappings(
-			$this->createPropertyId( 'P99002' ),
+			new NumericPropertyId( 'P99002' ),
 			new MappingList( [
 				new Mapping( 'foo:foo', 'https://example.com/#foo1' )
 			] )
 		);
 		$this->createPropertyWithMappings(
-			$this->createPropertyId( 'P99003' ),
+			new NumericPropertyId( 'P99003' ),
 			new MappingList( [
 				new Mapping( 'foo:foo', 'https://example.com/#foo1' ),
 				new Mapping( 'foo:bar', 'https://example.com/#bar1' ),
@@ -93,13 +85,13 @@ class SqlAllMappingsLookupTest extends WikibaseRdfIntegrationTest {
 				] )
 			),
 			new MappingListAndId(
-				$this->createPropertyId( 'P99002' ),
+				new NumericPropertyId( 'P99002' ),
 				new MappingList( [
 					new Mapping( 'foo:foo', 'https://example.com/#foo1' )
 				] )
 			),
 			new MappingListAndId(
-				$this->createPropertyId( 'P99003' ),
+				new NumericPropertyId( 'P99003' ),
 				new MappingList( [
 					new Mapping( 'foo:foo', 'https://example.com/#foo1' ),
 					new Mapping( 'foo:bar', 'https://example.com/#bar1' ),
@@ -138,7 +130,7 @@ class SqlAllMappingsLookupTest extends WikibaseRdfIntegrationTest {
 			] )
 		);
 		$this->setMappings(
-			$this->createPropertyId( 'P99002' ),
+			new NumericPropertyId( 'P99002' ),
 			new MappingList( [
 				new Mapping( 'foo:foo', 'https://example.com/#foo2' ),
 				new Mapping( 'foo:baz', 'https://example.com/#baz2' )
@@ -167,14 +159,14 @@ class SqlAllMappingsLookupTest extends WikibaseRdfIntegrationTest {
 					] )
 				),
 				new MappingListAndId(
-					$this->createPropertyId( 'P99002' ),
+					new NumericPropertyId( 'P99002' ),
 					new MappingList( [
 						new Mapping( 'foo:foo', 'https://example.com/#foo2' ),
 						new Mapping( 'foo:baz', 'https://example.com/#baz2' )
 					] )
 				),
 				new MappingListAndId(
-					$this->createPropertyId( 'P99003' ),
+					new NumericPropertyId( 'P99003' ),
 					new MappingList( [
 						new Mapping( 'foo:foo', 'https://example.com/#foo1' ),
 						new Mapping( 'foo:bar', 'https://example.com/#bar1' ),

--- a/tests/Persistence/UserBasedEntityMappingsAuthorizerTest.php
+++ b/tests/Persistence/UserBasedEntityMappingsAuthorizerTest.php
@@ -4,11 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\WikibaseRDF\Tests\Persistence;
 
-use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use MediaWiki\User\User;
 use ProfessionalWiki\WikibaseRDF\Persistence\UserBasedEntityMappingsAuthorizer;
 use ProfessionalWiki\WikibaseRDF\Tests\WikibaseRdfIntegrationTest;
 use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
-use User;
 use Wikibase\DataModel\Entity\ItemId;
 
 /**

--- a/tests/WikibaseRdfIntegrationTest.php
+++ b/tests/WikibaseRdfIntegrationTest.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\WikibaseRDF\Tests;
 
 use Article;
 use MediaWikiIntegrationTestCase;
+use MediaWiki\Title\Title;
 use ProfessionalWiki\WikibaseRDF\Application\MappingList;
 use ProfessionalWiki\WikibaseRDF\WikibaseRdfExtension;
 use Wikibase\DataModel\Entity\EntityId;
@@ -19,14 +20,10 @@ class WikibaseRdfIntegrationTest extends MediaWikiIntegrationTestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->tablesUsed[] = 'text';
-		$this->tablesUsed[] = 'slots';
-		$this->tablesUsed[] = 'slot_roles';
-		$this->tablesUsed[] = 'page';
 	}
 
 	protected function getPageHtml( string $pageTitle ): string {
-		$title = \Title::newFromText( $pageTitle );
+		$title = Title::newFromText( $pageTitle );
 
 		$article = new Article( $title, 0 );
 		$article->getContext()->getOutput()->setTitle( $title );


### PR DESCRIPTION
Have to drop support for older versions because the amount of upstream changes in MW core and Wikibase.

Key changes:
- Update REST API version to v1, the schema for the POST method has changed
- Deprecate old methods and classes
- Update CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded the extension to version 2.0.0, including refreshed REST API endpoints for saving mappings (now using version v1) with a structured JSON request body.
  - Enhanced alias support for special pages to improve display and accessibility.
- **Documentation**
  - Updated platform requirements to MediaWiki and Wikibase 1.43 or later.
- **Chores**
  - Raised the PHP version requirement to 8.1 and improved dependency and configuration setups for enhanced stability and performance.
  - Added `.gitignore` entry to ignore the `vendor` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->